### PR TITLE
Enable Sphinx nitpicky mode and resolve all documentation warnings

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -91,8 +91,12 @@ nitpick_ignore_regex = [
     (r"py:class", r"(ndim|dtype)=.*"),
     # Internal _src paths
     (r"py:class", r"warp\._src\..*"),
-    # wp.-prefixed types that Sphinx can't resolve (e.g., wp.array, wp.vec3, wp.Kernel)
-    (r"py:class", r"wp\..*"),
+    # Ctypes-based geometric types that can't be documented as classes (vec*, mat*, quat, etc.)
+    (r"py:class", r"warp\.(vec\d*[ifd]?|mat\d+[ifd]?|quat[fd]?|spatial_vector[fd]?|transform[fd]?)"),
+    # Short names for the same ctypes types (when not fully qualified)
+    (r"py:class", r"(vec\d*[ifd]?|mat\d+[ifd]?|quat[fd]?|spatial_vector[fd]?|transform[fd]?)"),
+    # Type aliases (DeviceLike is Union[Device, str, None])
+    (r"py:class", r"warp\.DeviceLike"),
     # Short type names used in FEM annotations (e.g., DeviceLike, Graph, Sample, Coords)
     (
         r"py:class",
@@ -410,6 +414,18 @@ def filter_builtin_docstrings(app, what, name, obj, options, lines):
             return
 
 
+def rewrite_wp_in_docstrings(app, what, name, obj, options, lines):
+    """Rewrite ``wp.`` import aliases to ``warp.`` in docstrings.
+
+    This complements rewrite_wp_aliases (which handles signatures) by also
+    fixing docstring content that references ``wp.`` types.
+    """
+    import re
+    for i, line in enumerate(lines):
+        if "wp." in line:
+            lines[i] = re.sub(r"\bwp\.", "warp.", line)
+
+
 def build_constant_docs_cache():
     """Build a cache of constant docstrings from all warp._src modules."""
     out = {}
@@ -485,6 +501,60 @@ def rewrite_internal_module_paths(app, doctree, docname):
             node.parent.replace(node, docutils.nodes.Text(new_text))
 
 
+def rewrite_wp_aliases(app, what, name, obj, options, signature, return_annotation):
+    """Rewrite ``wp.`` import aliases to ``warp.`` in autodoc signatures.
+
+    Modules that use ``from __future__ import annotations`` with ``import warp
+    as wp`` produce stringified annotations like ``"wp.array"`` instead of
+    ``"warp.array"``.  Sphinx cannot resolve the ``wp`` alias, so this hook
+    normalises them before cross-reference resolution.
+    """
+    import re
+
+    def _fix(text):
+        if text is None:
+            return None
+        return re.sub(r"\bwp\.", "warp.", text)
+
+    return _fix(signature), _fix(return_annotation)
+
+
+def resolve_wp_aliases(app, env, node, contnode):
+    """Resolve ``wp.*`` cross-references by retrying as ``warp.*``.
+
+    When ``from __future__ import annotations`` is active and a module uses
+    ``import warp as wp``, stringified annotations like ``wp.array`` end up in
+    Sphinx's type-description output.  The signature and docstring hooks cannot
+    intercept every code path (e.g. ``autodoc_typehints = "description"``), so
+    this ``missing-reference`` handler rewrites the target at resolution time.
+    """
+    import re
+
+    reftarget = node.get("reftarget", "")
+    if not re.match(r"^wp\.", reftarget):
+        return None  # not a wp.* reference, let Sphinx handle it
+
+    new_target = re.sub(r"^wp\.", "warp.", reftarget)
+    node["reftarget"] = new_target
+
+    # Also fix the displayed text if it still shows the wp.* name
+    if contnode and hasattr(contnode, "children") and contnode.children:
+        text_node = contnode.children[0]
+        if hasattr(text_node, "astext") and text_node.astext().startswith("wp."):
+            text_node.parent.replace(text_node, docutils.nodes.Text(
+                re.sub(r"^wp\.", "warp.", text_node.astext())
+            ))
+
+    # Re-resolve using Sphinx's domain
+    domain = env.get_domain("py")
+    try:
+        return domain.resolve_xref(env, node.get("refdoc", ""), app.builder,
+                                   node.get("reftype", "class"), new_target,
+                                   node, contnode)
+    except Exception:
+        return None
+
+
 def generate_reference_docs(app):
     """Generate API and language reference .rst files before Sphinx reads sources."""
     docs.generate_reference.run()
@@ -496,5 +566,8 @@ def setup(app):
     # reference .rst files exist before autosummary scans for stub directives.
     app.connect("builder-inited", generate_reference_docs, priority=400)
     app.connect("autodoc-process-docstring", filter_builtin_docstrings)
+    app.connect("autodoc-process-docstring", rewrite_wp_in_docstrings)
     app.connect("autodoc-process-docstring", populate_reexported_docstrings)
+    app.connect("autodoc-process-signature", rewrite_wp_aliases)
+    app.connect("missing-reference", resolve_wp_aliases)
     app.connect("doctree-resolved", rewrite_internal_module_paths)

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -69,7 +69,7 @@ extensions = [
 ]
 
 # Enable nitpicky mode to warn about unresolved references.
-nitpicky = False
+nitpicky = True
 
 # Ignore warnings for Warp types in function signatures that Sphinx can't
 # resolve without fully qualified names (e.g., "int32" vs "warp.int32").
@@ -87,10 +87,38 @@ nitpick_ignore_regex = [
     ),
     # Concrete numeric types
     (r"py:class", r"(int|uint|float)\d+"),
-    # Array type parameters from wp.array() annotations
-    (r"py:class", r"(ndim|dtype)=\w+"),
+    # Array type parameters from wp.array() annotations (e.g., "dtype=wp.float32", "ndim=3")
+    (r"py:class", r"(ndim|dtype)=.*"),
     # Internal _src paths
     (r"py:class", r"warp\._src\..*"),
+    # wp.-prefixed types that Sphinx can't resolve (e.g., wp.array, wp.vec3, wp.Kernel)
+    (r"py:class", r"wp\..*"),
+    # Short type names used in FEM annotations (e.g., DeviceLike, Graph, Sample, Coords)
+    (
+        r"py:class",
+        r"(DeviceLike|Graph|Struct|BlockType|Rows|Cols|Sample|Coords|ElementIndex|"
+        r"ElementArg|ElementEvalArg|ElementIndexArg|TopologyArg|EvalArg|"
+        r"BsrMatrixOrExpression|_Var|_FuncParams|FunctionMetadata|KernelHooks|"
+        r"launch_bounds_t|FieldRestriction|scalar|vec3)",
+    ),
+    # FEM nested type annotations (e.g., Geometry.CellArg, FieldLike.EvalArg)
+    (r"py:class", r"\w+\.\w+Arg"),
+    # External types from mocked or optional dependencies
+    (r"py:class", r"(np\.ndarray|paddle\.Tensor|Usd\.Stage|_ctypes\.Structure|builtins\.bool)"),
+    # numpy internal type annotations
+    (r"py:class", r"numpy\..*"),
+    # Annotation artifacts from type signatures (e.g., "optional", "array-like", "-", "3", "4")
+    (r"py:class", r"(optional|array-like|-|\d+)"),
+    # Stringified property/cached_property objects leaking into type annotations
+    (r"py:class", r"<(property|functools\.cached_property) object at .*>"),
+    # Quoted string annotations (e.g., "Operator")
+    (r"py:class", r'".*"'),
+    # Descriptive text accidentally parsed as type references
+    (r"py:class", r"The output format to use"),
+    # warp.DType / warp.dtype (not a real class in the Sphinx object inventory)
+    (r"py:class", r"warp\.[Dd][Tt]ype"),
+    # Autosummary-generated member stubs for Warp classes (Texture*, fem.*, etc.)
+    (r"py:obj", r"warp\.(Texture\w+|fixedarray|indexedarray|indexedfabricarray|fabricarray|fem\.).*"),
     # Internal C++/Python interop methods on geometric types
     (
         r"py:obj",
@@ -103,6 +131,14 @@ nitpick_ignore_regex = [
         r"py:obj",
         r".*\.(conjugate|bit_length|bit_count|to_bytes|from_bytes|as_integer_ratio|is_integer|real|imag|numerator|denominator)",
     ),
+    # FEM OUTSIDE constant (module-level, not exported to public API)
+    (r"py:data", r"OUTSIDE"),
+    # jax_callable lives in a mocked/optional submodule
+    (r"py:func", r"warp\.jax_experimental\.jax_callable"),
+    # Internal/unexported FEM functions referenced in docstrings
+    (r"py:func", r"warp\.fem\.enforce_nanogrid_grading"),
+    # Deprecated/internal OmniGraph function
+    (r"py:func", r"warp\.from_omni_graph_ptr"),
 ]
 
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -89,7 +89,8 @@ nitpick_ignore_regex = [
     ),
     # Concrete numeric types
     (r"py:class", r"(int|uint|float)\d+"),
-    # Array type parameters from wp.array() annotations (e.g., "dtype=wp.float32", "ndim=3")
+    # Array type parameters from warp.array() annotations (e.g., "dtype=warp.float32", "ndim=3")
+    # Sphinx splits "warp.array(dtype=float, ndim=3)" and tries to resolve each part as a class.
     (r"py:class", r"(ndim|dtype)=.*"),
     # Internal _src paths
     (r"py:class", r"warp\._src\..*"),
@@ -115,10 +116,6 @@ nitpick_ignore_regex = [
     (r"py:class", r"(optional|array-like|-|\d+)"),
     # Stringified property/cached_property objects leaking into type annotations
     (r"py:class", r"<(property|functools\.cached_property) object at .*>"),
-    # Quoted string annotations (e.g., "Operator")
-    (r"py:class", r'".*"'),
-    # Descriptive text accidentally parsed as type references
-    (r"py:class", r"The output format to use"),
     # warp.DType / warp.dtype (not a real class in the Sphinx object inventory)
     (r"py:class", r"warp\.[Dd][Tt]ype"),
     # Autosummary-generated member stubs for Warp classes (Texture*, fem.*, etc.)

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -14,6 +14,8 @@ import os
 import pkgutil
 import sys
 
+import re
+
 import docutils
 import sphinx
 from sphinx.ext.autosummary.generate import AutosummaryRenderer
@@ -92,18 +94,16 @@ nitpick_ignore_regex = [
     # Internal _src paths
     (r"py:class", r"warp\._src\..*"),
     # Ctypes-based geometric types that can't be documented as classes (vec*, mat*, quat, etc.)
-    (r"py:class", r"warp\.(vec\d*[ifd]?|mat\d+[ifd]?|quat[fd]?|spatial_vector[fd]?|transform[fd]?)"),
-    # Short names for the same ctypes types (when not fully qualified)
-    (r"py:class", r"(vec\d*[ifd]?|mat\d+[ifd]?|quat[fd]?|spatial_vector[fd]?|transform[fd]?)"),
+    (r"py:class", r"(warp\.)?(vec\d*[ihfd]?|mat\d+[ihfd]?|quat[hfd]?|spatial_(vector|matrix)[hfd]?|transform[hfd]?)"),
     # Type aliases (DeviceLike is Union[Device, str, None])
-    (r"py:class", r"warp\.DeviceLike"),
-    # Short type names used in FEM annotations (e.g., DeviceLike, Graph, Sample, Coords)
+    (r"py:class", r"(warp\.)?DeviceLike"),
+    # Type names used in FEM and internal annotations (e.g., Graph, Sample, Coords)
     (
         r"py:class",
-        r"(DeviceLike|Graph|Struct|BlockType|Rows|Cols|Sample|Coords|ElementIndex|"
+        r"(Graph|Struct|BlockType|Rows|Cols|Sample|Coords|ElementIndex|"
         r"ElementArg|ElementEvalArg|ElementIndexArg|TopologyArg|EvalArg|"
         r"BsrMatrixOrExpression|_Var|_FuncParams|FunctionMetadata|KernelHooks|"
-        r"launch_bounds_t|FieldRestriction|scalar|vec3)",
+        r"launch_bounds_t|FieldRestriction|scalar)",
     ),
     # FEM nested type annotations (e.g., Geometry.CellArg, FieldLike.EvalArg)
     (r"py:class", r"\w+\.\w+Arg"),
@@ -137,11 +137,11 @@ nitpick_ignore_regex = [
     ),
     # FEM OUTSIDE constant (module-level, not exported to public API)
     (r"py:data", r"OUTSIDE"),
-    # jax_callable lives in a mocked/optional submodule
+    # jax_callable lives in warp.jax_experimental (jax itself is mocked)
     (r"py:func", r"warp\.jax_experimental\.jax_callable"),
     # Internal/unexported FEM functions referenced in docstrings
     (r"py:func", r"warp\.fem\.enforce_nanogrid_grading"),
-    # Deprecated/internal OmniGraph function
+    # External OmniGraph function referenced in docstrings but defined outside this repo
     (r"py:func", r"warp\.from_omni_graph_ptr"),
 ]
 
@@ -418,10 +418,14 @@ def rewrite_wp_in_docstrings(app, what, name, obj, options, lines):
     """Rewrite ``wp.`` import aliases to ``warp.`` in docstrings.
 
     This complements rewrite_wp_aliases (which handles signatures) by also
-    fixing docstring content that references ``wp.`` types.
+    fixing docstring content that references ``wp.`` types.  Lines inside
+    doctest blocks (``>>>``, ``...``) are skipped to preserve copy-pasteable
+    code examples that use ``import warp as wp``.
     """
-    import re
     for i, line in enumerate(lines):
+        stripped = line.lstrip()
+        if stripped.startswith(">>>") or stripped.startswith("..."):
+            continue  # preserve code examples
         if "wp." in line:
             lines[i] = re.sub(r"\bwp\.", "warp.", line)
 
@@ -509,7 +513,6 @@ def rewrite_wp_aliases(app, what, name, obj, options, signature, return_annotati
     ``"warp.array"``.  Sphinx cannot resolve the ``wp`` alias, so this hook
     normalises them before cross-reference resolution.
     """
-    import re
 
     def _fix(text):
         if text is None:
@@ -528,31 +531,46 @@ def resolve_wp_aliases(app, env, node, contnode):
     intercept every code path (e.g. ``autodoc_typehints = "description"``), so
     this ``missing-reference`` handler rewrites the target at resolution time.
     """
-    import re
-
     reftarget = node.get("reftarget", "")
-    if not re.match(r"^wp\.", reftarget):
+    if not reftarget.startswith("wp."):
         return None  # not a wp.* reference, let Sphinx handle it
 
-    new_target = re.sub(r"^wp\.", "warp.", reftarget)
-    node["reftarget"] = new_target
+    new_target = "warp." + reftarget[3:]
 
-    # Also fix the displayed text if it still shows the wp.* name
+    # Save originals so we can restore on failed resolution
+    orig_target = reftarget
+    orig_text = None
+    text_node = None
     if contnode and hasattr(contnode, "children") and contnode.children:
         text_node = contnode.children[0]
         if hasattr(text_node, "astext") and text_node.astext().startswith("wp."):
-            text_node.parent.replace(text_node, docutils.nodes.Text(
-                re.sub(r"^wp\.", "warp.", text_node.astext())
-            ))
+            orig_text = text_node.astext()
+
+    # Rewrite target and display text
+    node["reftarget"] = new_target
+    if orig_text is not None:
+        text_node.parent.replace(text_node, docutils.nodes.Text(
+            "warp." + orig_text[3:]
+        ))
 
     # Re-resolve using Sphinx's domain
     domain = env.get_domain("py")
-    try:
-        return domain.resolve_xref(env, node.get("refdoc", ""), app.builder,
-                                   node.get("reftype", "class"), new_target,
-                                   node, contnode)
-    except Exception:
-        return None
+    result = domain.resolve_xref(env, node.get("refdoc", ""), app.builder,
+                                 node.get("reftype", "class"), new_target,
+                                 node, contnode)
+
+    if result is not None:
+        return result
+
+    # Resolution failed — restore original values so Sphinx reports the
+    # correct target name in any warning
+    node["reftarget"] = orig_target
+    if orig_text is not None and text_node is not None:
+        new_text_node = contnode.children[0] if contnode.children else None
+        if new_text_node is not None:
+            new_text_node.parent.replace(new_text_node, docutils.nodes.Text(orig_text))
+
+    return None
 
 
 def generate_reference_docs(app):

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -73,29 +73,25 @@ extensions = [
 # Enable nitpicky mode to warn about unresolved references.
 nitpicky = True
 
-# Ignore warnings for Warp types in function signatures that Sphinx can't
-# resolve without fully qualified names (e.g., "int32" vs "warp.int32").
-# This includes:
-# - Type aliases (Scalar, Int, Float, Vector, Quaternion, Matrix, Array, Transformation, Tile)
-# - Array types (IndexedArray, IndexedFabricArray, FabricArray)
-# - Concrete types (int8, int16, int32, int64, uint8, uint16, uint32, uint64, float16, float32, float64)
-# - Array type parameters (ndim=3, dtype=float32) from wp.array() annotations
-# - Internal _src paths that leak into type annotations
+# Suppress warnings for types that Sphinx cannot resolve due to structural
+# limitations (dynamic ctypes types, py:data/py:class role mismatches,
+# mocked dependencies, runtime repr leaking into signatures, etc.).
 nitpick_ignore_regex = [
-    # Warp type aliases and meta-types
+    # Public type aliases indexed as py:data but referenced as py:class (Sphinx limitation)
+    (r"py:class", r"(warp\.)?(Scalar|Int|Float|DeviceLike)"),
+    # Internal meta-types used in builtin function signatures (not exported)
     (
         r"py:class",
-        r"(Scalar|Int|Float|Vector|Quaternion|Matrix|Array|Transformation|Tile|IndexedArray|IndexedFabricArray|FabricArray|Shape|DType|Any)",
+        r"(Vector|Quaternion|Matrix|Array|Transformation|Tile|IndexedArray|IndexedFabricArray|FabricArray|Shape|DType|Any)",
     ),
     # Array type parameters from warp.array() annotations (e.g., "dtype=warp.float32", "ndim=3")
     # Sphinx splits "warp.array(dtype=float, ndim=3)" and tries to resolve each part as a class.
     (r"py:class", r"(ndim|dtype)=.*"),
-    # Internal _src paths
+    # Internal _src paths that leak into annotations via from __future__ import annotations
+    # (411 warnings across ~65 files; fixing requires project-wide annotation refactor)
     (r"py:class", r"warp\._src\..*"),
     # Ctypes-based geometric types that can't be documented as classes (vec*, mat*, quat, etc.)
     (r"py:class", r"(warp\.)?(vec\d*[ihfd]?|mat\d+[ihfd]?|quat[hfd]?|spatial_(vector|matrix)[hfd]?|transform[hfd]?)"),
-    # Type aliases (DeviceLike is Union[Device, str, None])
-    (r"py:class", r"(warp\.)?DeviceLike"),
     # Type names used in FEM and internal annotations (e.g., Graph, Sample, Coords)
     (
         r"py:class",
@@ -104,14 +100,12 @@ nitpick_ignore_regex = [
         r"BsrMatrixOrExpression|_Var|_FuncParams|FunctionMetadata|KernelHooks|"
         r"launch_bounds_t|FieldRestriction|scalar)",
     ),
-    # FEM nested type annotations (e.g., Geometry.CellArg, FieldLike.EvalArg)
-    (r"py:class", r"\w+\.\w+Arg"),
-    # External types from mocked or optional dependencies
-    (r"py:class", r"(np\.ndarray|paddle\.Tensor|Usd\.Stage|_ctypes\.Structure|builtins\.bool)"),
+    # FEM nested type annotations (e.g., Geometry.CellArg, FunctionSpace.dof_dtype)
+    (r"py:class", r"\w+\.(\w*Arg|\w*dtype|LocalValueMap)"),
+    # External/mocked types and builtins.bool (Warp shadows bool, forcing builtins.bool in annotations)
+    (r"py:class", r"(paddle\.Tensor|Usd\.Stage|_ctypes\.Structure|builtins\.bool)"),
     # numpy internal type annotations
     (r"py:class", r"numpy\..*"),
-    # Annotation artifacts from type signatures (e.g., "optional", "array-like", "-", "3", "4")
-    (r"py:class", r"(optional|array-like|-|\d+)"),
     # Stringified property/cached_property objects leaking into type annotations
     (r"py:class", r"<(property|functools\.cached_property) object at .*>"),
     # Autosummary-generated member stubs for Warp classes (Texture*, fem.*, etc.)

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -87,8 +87,6 @@ nitpick_ignore_regex = [
         r"py:class",
         r"(Scalar|Int|Float|Vector|Quaternion|Matrix|Array|Transformation|Tile|IndexedArray|IndexedFabricArray|FabricArray|Shape|DType|Any)",
     ),
-    # Concrete numeric types
-    (r"py:class", r"(int|uint|float)\d+"),
     # Array type parameters from warp.array() annotations (e.g., "dtype=warp.float32", "ndim=3")
     # Sphinx splits "warp.array(dtype=float, ndim=3)" and tries to resolve each part as a class.
     (r"py:class", r"(ndim|dtype)=.*"),
@@ -116,8 +114,6 @@ nitpick_ignore_regex = [
     (r"py:class", r"(optional|array-like|-|\d+)"),
     # Stringified property/cached_property objects leaking into type annotations
     (r"py:class", r"<(property|functools\.cached_property) object at .*>"),
-    # warp.DType / warp.dtype (not a real class in the Sphinx object inventory)
-    (r"py:class", r"warp\.[Dd][Tt]ype"),
     # Autosummary-generated member stubs for Warp classes (Texture*, fem.*, etc.)
     (r"py:obj", r"warp\.(Texture\w+|fixedarray|indexedarray|indexedfabricarray|fabricarray|fem\.).*"),
     # Internal C++/Python interop methods on geometric types
@@ -132,14 +128,8 @@ nitpick_ignore_regex = [
         r"py:obj",
         r".*\.(conjugate|bit_length|bit_count|to_bytes|from_bytes|as_integer_ratio|is_integer|real|imag|numerator|denominator)",
     ),
-    # FEM OUTSIDE constant (module-level, not exported to public API)
-    (r"py:data", r"OUTSIDE"),
     # jax_callable lives in warp.jax_experimental (jax itself is mocked)
     (r"py:func", r"warp\.jax_experimental\.jax_callable"),
-    # Internal/unexported FEM functions referenced in docstrings
-    (r"py:func", r"warp\.fem\.enforce_nanogrid_grading"),
-    # External OmniGraph function referenced in docstrings but defined outside this repo
-    (r"py:func", r"warp\.from_omni_graph_ptr"),
 ]
 
 

--- a/warp/__init__.pyi
+++ b/warp/__init__.pyi
@@ -2017,7 +2017,7 @@ def round(x: Float) -> Float:
 
     This is the most intuitive form of rounding in the colloquial sense, but can be slower than other options like
     :func:`~warp._src.lang.rint`.
-    Differs from :func:`numpy.round`, which behaves the same way as :func:`numpy.rint`.
+    Differs from :func:`numpy.round`, which behaves the same way as :obj:`numpy.rint`.
     """
     ...
 
@@ -2025,7 +2025,7 @@ def rint(x: Float) -> Float:
     """Compute the nearest integer value to ``x``, rounding halfway cases to nearest even integer.
 
     It is generally faster than :func:`~warp._src.lang.round`.
-    Equivalent to :func:`numpy.rint`.
+    Equivalent to :obj:`numpy.rint`.
     """
     ...
 
@@ -2034,7 +2034,7 @@ def trunc(x: Float) -> Float:
 
     In other words, it discards the fractional part of ``x``.
     It is similar to casting ``float(int(a))``, but preserves the negative sign when ``x`` is in the range [-0.0, -1.0).
-    Equivalent to :func:`numpy.trunc` and :func:`numpy.fix`.
+    Equivalent to :obj:`numpy.trunc` and :func:`numpy.fix`.
     """
     ...
 
@@ -3697,7 +3697,7 @@ def tile_sort(keys: Tile[Any, tuple[int]], values: Tile[Any, tuple[int]]) -> Non
     """Cooperatively sort the elements of two tiles in ascending order based on the keys, using all threads in the block.
 
     Args:
-        keys: Keys to sort by. Supported key types: :class:`float32`, :class:`int32`, :class:`uint32`, :class:`int64`, :class:`uint64`. Must be in shared memory.
+        keys: Keys to sort by. Supported key types: :class:`warp.float32`, :class:`warp.int32`, :class:`warp.uint32`, :class:`warp.int64`, :class:`warp.uint64`. Must be in shared memory.
         values: Values to sort along with keys. No type restrictions. Must be in shared memory.
 
     Returns:
@@ -4772,11 +4772,11 @@ def volume_store_v(id: uint64, i: int32, j: int32, k: int32, value: vec3f) -> No
     ...
 
 def volume_sample_i(id: uint64, uvw: vec3f) -> int:
-    """Sample the :class:`int32` volume given by ``id`` at the volume local-space point ``uvw``."""
+    """Sample the :class:`warp.int32` volume given by ``id`` at the volume local-space point ``uvw``."""
     ...
 
 def volume_lookup_i(id: uint64, i: int32, j: int32, k: int32) -> int:
-    """Query the :class:`int32` value of voxel with coordinates ``i``, ``j``, ``k``.
+    """Query the :class:`warp.int32` value of voxel with coordinates ``i``, ``j``, ``k``.
 
     If the voxel at this index does not exist, this function returns the background value.
     """

--- a/warp/_src/builtins.py
+++ b/warp/_src/builtins.py
@@ -322,7 +322,7 @@ add_builtin(
 
     This is the most intuitive form of rounding in the colloquial sense, but can be slower than other options like
     :func:`~warp._src.lang.rint`.
-    Differs from :func:`numpy.round`, which behaves the same way as :func:`numpy.rint`.""",
+    Differs from :func:`numpy.round`, which behaves the same way as :obj:`numpy.rint`.""",
     is_differentiable=False,
 )
 
@@ -334,7 +334,7 @@ add_builtin(
     doc="""Compute the nearest integer value to ``x``, rounding halfway cases to nearest even integer.
 
     It is generally faster than :func:`~warp._src.lang.round`.
-    Equivalent to :func:`numpy.rint`.""",
+    Equivalent to :obj:`numpy.rint`.""",
     is_differentiable=False,
 )
 
@@ -347,7 +347,7 @@ add_builtin(
 
     In other words, it discards the fractional part of ``x``.
     It is similar to casting ``float(int(a))``, but preserves the negative sign when ``x`` is in the range [-0.0, -1.0).
-    Equivalent to :func:`numpy.trunc` and :func:`numpy.fix`.""",
+    Equivalent to :obj:`numpy.trunc` and :func:`numpy.fix`.""",
     is_differentiable=False,
 )
 

--- a/warp/_src/builtins.py
+++ b/warp/_src/builtins.py
@@ -5106,7 +5106,7 @@ add_builtin(
     doc="""Cooperatively sort the elements of two tiles in ascending order based on the keys, using all threads in the block.
 
     Args:
-        keys: Keys to sort by. Supported key types: :class:`float32`, :class:`int32`, :class:`uint32`, :class:`int64`, :class:`uint64`. Must be in shared memory.
+        keys: Keys to sort by. Supported key types: :class:`warp.float32`, :class:`warp.int32`, :class:`warp.uint32`, :class:`warp.int64`, :class:`warp.uint64`. Must be in shared memory.
         values: Values to sort along with keys. No type restrictions. Must be in shared memory.
 
     Returns:
@@ -7616,7 +7616,7 @@ add_builtin(
     input_types={"id": uint64, "uvw": vec3},
     value_type=int,
     group="Volumes",
-    doc="""Sample the :class:`int32` volume given by ``id`` at the volume local-space point ``uvw``.""",
+    doc="""Sample the :class:`warp.int32` volume given by ``id`` at the volume local-space point ``uvw``.""",
 )
 
 add_builtin(
@@ -7624,7 +7624,7 @@ add_builtin(
     input_types={"id": uint64, "i": int, "j": int, "k": int},
     value_type=int,
     group="Volumes",
-    doc="""Query the :class:`int32` value of voxel with coordinates ``i``, ``j``, ``k``.
+    doc="""Query the :class:`warp.int32` value of voxel with coordinates ``i``, ``j``, ``k``.
 
     If the voxel at this index does not exist, this function returns the background value.""",
     is_differentiable=False,

--- a/warp/_src/context.py
+++ b/warp/_src/context.py
@@ -8338,7 +8338,7 @@ condition_host = None
 
 
 def capture_if(
-    condition: warp.array(dtype=int),
+    condition: warp.array[int],
     on_true: Callable | Graph | None = None,
     on_false: Callable | Graph | None = None,
     stream: Stream = None,
@@ -8486,7 +8486,7 @@ def capture_if(
 
 
 def capture_while(
-    condition: warp.array(dtype=int), while_body: Callable | Graph, stream: Stream | None = None, **kwargs
+    condition: warp.array[int], while_body: Callable | Graph, stream: Stream | None = None, **kwargs
 ):
     """Create a dynamic loop based on a condition.
 

--- a/warp/_src/context.py
+++ b/warp/_src/context.py
@@ -3792,7 +3792,7 @@ class Device:
                 If ``None``, falls back to global config or automatic determination.
 
         Returns:
-            The output format to use: ``"ptx"``, ``"cubin"``, or ``None`` for CPU devices.
+            ``"ptx"``, ``"cubin"``, or ``None`` for CPU devices.
         """
 
         if self.is_cpu:

--- a/warp/_src/fem/adaptivity.py
+++ b/warp/_src/fem/adaptivity.py
@@ -27,7 +27,7 @@ def adaptive_nanogrid_from_hierarchy(
 
     Args:
         grids: List of sparse Volumes, from finest to coarsest
-        grading: Supplementary grading condition, may be ``None``, "face" or "vertex"; see :func:`enforce_nanogrid_grading`
+        grading: Supplementary grading condition, may be ``None``, "face" or "vertex"; see :func:`warp.fem.enforce_nanogrid_grading`
         temporary_store: Storage for temporary allocations
     """
     if not grids:
@@ -105,7 +105,7 @@ def adaptive_nanogrid_from_field(
         refinement_field: Scalar field used as a refinement oracle. If the returned value is negative, the corresponding voxel will be carved out.
             Positive values indicate the desired refinement with 0.0 corresponding to the finest level and 1.0 to the coarsest level.
         samples_per_voxel: How many samples to use for evaluating the refinement field within each voxel
-        grading: Supplementary grading condition, may be ``None``, "face" or "vertex"; see :func:`enforce_nanogrid_grading`
+        grading: Supplementary grading condition, may be ``None``, "face" or "vertex"; see :func:`warp.fem.enforce_nanogrid_grading`
         temporary_store: Storage for temporary allocations
     """
 

--- a/warp/_src/fem/adaptivity.py
+++ b/warp/_src/fem/adaptivity.py
@@ -27,7 +27,7 @@ def adaptive_nanogrid_from_hierarchy(
 
     Args:
         grids: List of sparse Volumes, from finest to coarsest
-        grading: Supplementary grading condition, may be ``None``, "face" or "vertex"; see :func:`warp.fem.enforce_nanogrid_grading`
+        grading: Supplementary grading condition, may be ``None``, "face" or "vertex"; ``"face"`` ensures cells sharing a face differ by at most one level, ``"vertex"`` extends this to vertex neighbors
         temporary_store: Storage for temporary allocations
     """
     if not grids:
@@ -105,7 +105,7 @@ def adaptive_nanogrid_from_field(
         refinement_field: Scalar field used as a refinement oracle. If the returned value is negative, the corresponding voxel will be carved out.
             Positive values indicate the desired refinement with 0.0 corresponding to the finest level and 1.0 to the coarsest level.
         samples_per_voxel: How many samples to use for evaluating the refinement field within each voxel
-        grading: Supplementary grading condition, may be ``None``, "face" or "vertex"; see :func:`warp.fem.enforce_nanogrid_grading`
+        grading: Supplementary grading condition, may be ``None``, "face" or "vertex"; ``"face"`` ensures cells sharing a face differ by at most one level, ``"vertex"`` extends this to vertex neighbors
         temporary_store: Storage for temporary allocations
     """
 

--- a/warp/_src/fem/cache.py
+++ b/warp/_src/fem/cache.py
@@ -104,7 +104,7 @@ def get_func(func, suffix: Any, code_transformers=None, allow_overloads=False):
 
 
 def dynamic_func(suffix: Any, code_transformers=None, allow_overloads=False):
-    """Return a decorator that caches a specialized :class:`wp.Function`.
+    """Return a decorator that caches a specialized :class:`warp.Function`.
 
     Args:
         suffix: Hashable key used to specialize and cache the function.
@@ -112,7 +112,7 @@ def dynamic_func(suffix: Any, code_transformers=None, allow_overloads=False):
         allow_overloads: Whether to include argument types in the cache key.
 
     Returns:
-        A decorator that registers and returns a cached :class:`wp.Function`.
+        A decorator that registers and returns a cached :class:`warp.Function`.
     """
 
     def wrap_func(func: Callable):
@@ -141,7 +141,7 @@ def get_kernel(
 
 
 def dynamic_kernel(suffix: Any, kernel_options: Optional[dict[str, Any]] = None, allow_overloads=False):
-    """Return a decorator that caches a specialized :class:`wp.Kernel`.
+    """Return a decorator that caches a specialized :class:`warp.Kernel`.
 
     Args:
         suffix: Hashable key used to specialize and cache the kernel.
@@ -149,7 +149,7 @@ def dynamic_kernel(suffix: Any, kernel_options: Optional[dict[str, Any]] = None,
         allow_overloads: Whether to include argument types in the cache key.
 
     Returns:
-        A decorator that registers and returns a cached :class:`wp.Kernel`.
+        A decorator that registers and returns a cached :class:`warp.Kernel`.
     """
     if kernel_options is None:
         kernel_options = {}

--- a/warp/_src/fem/cache.py
+++ b/warp/_src/fem/cache.py
@@ -434,7 +434,7 @@ class TemporaryStore:
     """
     Shared pool of temporary arrays that will be persisted and reused across invocations of ``warp.fem`` functions.
 
-    A :class:`TemporaryStore` instance may either be passed explicitly to ``warp.fem`` functions that accept such an argument, for instance :func:`.integrate.integrate`,
+    A :class:`TemporaryStore` instance may either be passed explicitly to ``warp.fem`` functions that accept such an argument, for instance :func:`warp.fem.integrate`,
     or can be set globally as the default store using :func:`set_default_temporary_store`.
 
     By default, there is no default temporary store, so that temporary allocations are not persisted.

--- a/warp/_src/fem/geometry/adaptive_nanogrid.py
+++ b/warp/_src/fem/geometry/adaptive_nanogrid.py
@@ -349,7 +349,7 @@ class AdaptiveNanogrid(NanogridBase):
         element_index: ElementIndex,
         element_coords: Coords,
     ):
-        """Convert cell coordinates to side coordinates, or :data:`OUTSIDE`."""
+        """Convert cell coordinates to side coordinates, or :data:`warp.fem.OUTSIDE`."""
         flags = args.face_flags[side_index]
         axis = NanogridBase._get_face_axis(flags)
         flip = NanogridBase._get_face_inner_offset(flags)

--- a/warp/_src/fem/geometry/deformed_geometry.py
+++ b/warp/_src/fem/geometry/deformed_geometry.py
@@ -43,7 +43,7 @@ class DeformedGeometry(Geometry):
         "side_coordinates": lambda obj: obj._make_side_coordinates(),
     }
 
-    def __init__(self, field: "wp.fem.GeometryField", relative: bool = True, build_bvh: bool = False):
+    def __init__(self, field: "warp.fem.GeometryField", relative: bool = True, build_bvh: bool = False):
         """Construct a Deformed Geometry from a displacement or absolute position field defined over a base geometry.
         The deformation field does not need to be isoparameteric.
 

--- a/warp/_src/fem/geometry/geometry.py
+++ b/warp/_src/fem/geometry/geometry.py
@@ -225,7 +225,7 @@ class Geometry:
         element_index: ElementIndex,
         element_coords: Coords,
     ):
-        """Device function converting coordinates on a cell to coordinates on a side, or :data:`OUTSIDE`"""
+        """Device function converting coordinates on a cell to coordinates on a side, or :data:`warp.fem.OUTSIDE`"""
         raise NotImplementedError
 
     @staticmethod

--- a/warp/_src/fem/geometry/grid_2d.py
+++ b/warp/_src/fem/geometry/grid_2d.py
@@ -478,7 +478,7 @@ class Grid2D(Geometry):
         element_index: ElementIndex,
         element_coords: Coords,
     ):
-        """Convert cell coordinates to side coordinates, or :data:`OUTSIDE`."""
+        """Convert cell coordinates to side coordinates, or :data:`warp.fem.OUTSIDE`."""
         side = Grid2D.get_side(args, side_index)
         cell = Grid2D.get_cell(args.cell_arg.res, element_index)
 

--- a/warp/_src/fem/geometry/grid_3d.py
+++ b/warp/_src/fem/geometry/grid_3d.py
@@ -534,7 +534,7 @@ class Grid3D(Geometry):
         element_index: ElementIndex,
         element_coords: Coords,
     ):
-        """Convert cell coordinates to side coordinates, or :data:`OUTSIDE`."""
+        """Convert cell coordinates to side coordinates, or :data:`warp.fem.OUTSIDE`."""
         side = Grid3D.get_side(args, side_index)
         cell = Grid3D.get_cell(args.cell_arg.res, element_index)
 

--- a/warp/_src/fem/geometry/hexmesh.py
+++ b/warp/_src/fem/geometry/hexmesh.py
@@ -432,7 +432,7 @@ class Hexmesh(Geometry):
 
     @wp.func
     def side_from_cell_coords(args: SideArg, side_index: ElementIndex, hex_index: ElementIndex, hex_coords: Coords):
-        """Convert cell coordinates to side coordinates, or :data:`OUTSIDE`."""
+        """Convert cell coordinates to side coordinates, or :data:`warp.fem.OUTSIDE`."""
         if Hexmesh.side_inner_cell_index(args, side_index) == hex_index:
             local_face_index = args.face_hex_face_orientation[side_index][0]
             face_orientation = args.face_hex_face_orientation[side_index][1]

--- a/warp/_src/fem/geometry/nanogrid.py
+++ b/warp/_src/fem/geometry/nanogrid.py
@@ -516,7 +516,7 @@ class Nanogrid(NanogridBase):
         element_index: ElementIndex,
         element_coords: Coords,
     ):
-        """Convert cell coordinates to side coordinates, or :data:`OUTSIDE`."""
+        """Convert cell coordinates to side coordinates, or :data:`warp.fem.OUTSIDE`."""
         flags = args.face_flags[side_index]
         axis = Nanogrid._get_face_axis(flags)
         flip = Nanogrid._get_face_inner_offset(flags)

--- a/warp/_src/fem/geometry/partition.py
+++ b/warp/_src/fem/geometry/partition.py
@@ -452,7 +452,7 @@ class ExplicitGeometryPartition(CellBasedGeometryPartition):
     def __init__(
         self,
         geometry: Geometry,
-        cell_mask: "wp.array(dtype=int)",
+        cell_mask: "warp.array(dtype=int)",
         max_cell_count: int = -1,
         max_side_count: int = -1,
         temporary_store: Optional[cache.TemporaryStore] = None,
@@ -482,7 +482,7 @@ class ExplicitGeometryPartition(CellBasedGeometryPartition):
 
     def rebuild(
         self,
-        cell_mask: "wp.array(dtype=int)",
+        cell_mask: "warp.array(dtype=int)",
         temporary_store: Optional[cache.TemporaryStore] = None,
     ):
         """Rebuild the geometry partition from a new active cell mask.

--- a/warp/_src/fem/geometry/quadmesh.py
+++ b/warp/_src/fem/geometry/quadmesh.py
@@ -479,7 +479,7 @@ class Quadmesh(Geometry):
         quad_index: ElementIndex,
         quad_coords: Coords,
     ):
-        """Convert cell coordinates to side coordinates, or :data:`OUTSIDE`."""
+        """Convert cell coordinates to side coordinates, or :data:`warp.fem.OUTSIDE`."""
         return Quadmesh._quad_to_edge_coords(args.topology, side_index, quad_index, quad_coords)
 
     @wp.func

--- a/warp/_src/fem/geometry/tetmesh.py
+++ b/warp/_src/fem/geometry/tetmesh.py
@@ -286,7 +286,7 @@ class Tetmesh(Geometry):
 
     @wp.func
     def side_from_cell_coords(args: SideArg, side_index: ElementIndex, tet_index: ElementIndex, tet_coords: Coords):
-        """Convert cell coordinates to side coordinates, or :data:`OUTSIDE`."""
+        """Convert cell coordinates to side coordinates, or :data:`warp.fem.OUTSIDE`."""
         fvi = args.face_vertex_indices[side_index]
 
         tv1 = args.cell_arg.tet_vertex_indices[tet_index, 1]

--- a/warp/_src/fem/geometry/trimesh.py
+++ b/warp/_src/fem/geometry/trimesh.py
@@ -493,7 +493,7 @@ class Trimesh(Geometry):
         tri_index: ElementIndex,
         tri_coords: Coords,
     ):
-        """Convert cell coordinates to side coordinates, or :data:`OUTSIDE`."""
+        """Convert cell coordinates to side coordinates, or :data:`warp.fem.OUTSIDE`."""
         return Trimesh._tri_to_edge_coords(args.topology, side_index, tri_index, tri_coords)
 
 

--- a/warp/_src/fem/operator.py
+++ b/warp/_src/fem/operator.py
@@ -30,7 +30,7 @@ class Integrand:
         module (Any): Warp module where the integrand is registered.
         argspec (Any): Full argument specification for the integrand function.
         kernel_options (dict[str, Any]): Kernel options used during kernel generation.
-        operators (Optional[dict[str, set["Operator"]]]): Resolved operators for field arguments, populated on first integrate call.
+        operators (Optional[dict[str, set[Operator]]]): Resolved operators for field arguments, populated on first integrate call.
         cached_kernels (dict[Any, Any]): Cache of compiled kernels by specialization key.
         cached_funcs (dict[Any, Any]): Cache of specialized functions by specialization key.
     """

--- a/warp/_src/fem/operator.py
+++ b/warp/_src/fem/operator.py
@@ -267,7 +267,7 @@ def to_outer_cell(domain: Domain, s: Sample):
 def to_cell_side(domain: Domain, cell_s: Sample, side_index: ElementIndex):
     """Convert a :class:`Sample` defined on a cell to a sample defined on one of its side.
 
-    If the result does not lie on the side ``side_index``, the resulting coordinates will be set to :data:`OUTSIDE`.
+    If the result does not lie on the side ``side_index``, the resulting coordinates will be set to :data:`warp.fem.OUTSIDE`.
     """
     return make_free_sample(
         side_index,

--- a/warp/_src/fem/quadrature/pic_quadrature.py
+++ b/warp/_src/fem/quadrature/pic_quadrature.py
@@ -49,18 +49,18 @@ class PicQuadrature(Quadrature):
         self,
         domain: GeometryDomain,
         positions: Union[
-            "wp.array",
+            "warp.array",
             tuple[
-                "wp.array(dtype=ElementIndex)",
-                "wp.array(dtype=Coords)",
+                "warp.array(dtype=ElementIndex)",
+                "warp.array(dtype=Coords)",
             ],
             tuple[
-                "wp.array2d(dtype=ElementIndex)",
-                "wp.array2d(dtype=Coords)",
-                "wp.array2d(dtype=float)",
+                "warp.array2d(dtype=ElementIndex)",
+                "warp.array2d(dtype=Coords)",
+                "warp.array2d(dtype=float)",
             ],
         ],
-        measures: Optional["wp.array(dtype=float)"] = None,
+        measures: Optional["warp.array(dtype=float)"] = None,
         requires_grad: bool = False,
         max_dist: float = 0.0,
         use_domain_element_indices: bool = False,
@@ -243,7 +243,7 @@ class PicQuadrature(Quadrature):
     ):
         return qp_arg.cell_particle_offsets[domain_element_index] + index
 
-    def fill_element_mask(self, mask: "wp.array(dtype=int)"):
+    def fill_element_mask(self, mask: "warp.array(dtype=int)"):
         """Fills a mask array such that all non-empty elements are set to 1, all empty elements to zero.
 
         Args:

--- a/warp/_src/fem/quadrature/quadrature.py
+++ b/warp/_src/fem/quadrature/quadrature.py
@@ -563,8 +563,8 @@ class ExplicitQuadrature(_QuadratureWithRegularEvaluationPoints):
     def __init__(
         self,
         domain: GeometryDomain,
-        points: "wp.array2d(dtype=Coords)",
-        weights: "wp.array2d(dtype=float)",
+        points: "warp.array2d(dtype=Coords)",
+        weights: "warp.array2d(dtype=float)",
     ):
         if points.shape != weights.shape:
             raise ValueError("Points and weights arrays must have the same shape")

--- a/warp/_src/fem/space/basis_function_space.py
+++ b/warp/_src/fem/space/basis_function_space.py
@@ -72,7 +72,7 @@ class CollocatedFunctionSpace(FunctionSpace):
     def make_field(
         self,
         space_partition: Optional[SpacePartition] = None,
-    ) -> "wp._src.fem.NodalField":
+    ) -> "warp._src.fem.NodalField":
         """Create a discrete field over this function space.
 
         Args:
@@ -218,7 +218,7 @@ class VectorValuedFunctionSpace(FunctionSpace):
     def make_field(
         self,
         space_partition: Optional[SpacePartition] = None,
-    ) -> "wp._src.fem.NodalField":
+    ) -> "warp._src.fem.NodalField":
         """Create a discrete field over this function space.
 
         Args:

--- a/warp/_src/fem/space/function_space.py
+++ b/warp/_src/fem/space/function_space.py
@@ -170,9 +170,9 @@ class FunctionSpace:
         """Assemble the world-space value of the function space.
 
         Args:
-         - dof_value: node value in the degrees-of-freedom basis
-         - node_weight: weight associated to the node, as given per the basis space
-         - local_value_map: data encoding local transformation from node space to world space, as given per ``local_map_value_(inn|out)er``
+            dof_value: Node value in the degrees-of-freedom basis.
+            node_weight: Weight associated to the node, as given per the basis space.
+            local_value_map: Data encoding local transformation from node space to world space, as given per ``local_map_value_(inn|out)er``.
         """
         raise NotImplementedError
 
@@ -185,9 +185,9 @@ class FunctionSpace:
         """Assemble the world-space gradient of the function space.
 
         Args:
-         - dof_value: node value in the degrees-of-freedom basis
-         - node_weight_gradient: gradient of the weight associated to the node, either w.r.t element or world space
-         - local_value_map: data encoding local transformation from node space to world space, as given per ``local_map_value_(inn|out)er``
+            dof_value: Node value in the degrees-of-freedom basis.
+            node_weight_gradient: Gradient of the weight associated to the node, either w.r.t element or world space.
+            local_value_map: Data encoding local transformation from node space to world space, as given per ``local_map_value_(inn|out)er``.
         """
         raise NotImplementedError
 
@@ -200,9 +200,9 @@ class FunctionSpace:
         """Assemble the world-space divergence of the function space.
 
         Args:
-         - dof_value: node value in the degrees-of-freedom basis
-         - node_weight_gradient: gradient of the weight associated to the node, either w.r.t element or world space
-         - local_value_map: data encoding local transformation from node space to world space, as given per ``local_map_value_(inn|out)er``
+            dof_value: Node value in the degrees-of-freedom basis.
+            node_weight_gradient: Gradient of the weight associated to the node, either w.r.t element or world space.
+            local_value_map: Data encoding local transformation from node space to world space, as given per ``local_map_value_(inn|out)er``.
         """
         raise NotImplementedError
 
@@ -215,8 +215,8 @@ class FunctionSpace:
         """Compute the projection of a world-space value onto the basis of a single degree of freedom.
 
         Args:
-            - space_value: world-space value
-            - node_weight: weight associated to the node, as given per the basis space
-            - local_value_map: data encoding local transformation from node space to world space, as given per ``local_map_value_(inn|out)er``
+            space_value: World-space value.
+            node_weight: Weight associated to the node, as given per the basis space.
+            local_value_map: Data encoding local transformation from node space to world space, as given per ``local_map_value_(inn|out)er``.
         """
         raise NotImplementedError

--- a/warp/_src/fem/space/restriction.py
+++ b/warp/_src/fem/space/restriction.py
@@ -61,7 +61,7 @@ class SpaceRestriction:
 
         self.rebuild(device=device, temporary_store=temporary_store)
 
-    def rebuild(self, device: Optional["wp.DeviceLike"] = None, temporary_store: Optional[cache.TemporaryStore] = None):
+    def rebuild(self, device: Optional["warp.DeviceLike"] = None, temporary_store: Optional[cache.TemporaryStore] = None):
         """Rebuild internal indices for the space restriction."""
         max_nodes_per_element = self.space_topology.MAX_NODES_PER_ELEMENT
 

--- a/warp/_src/jax.py
+++ b/warp/_src/jax.py
@@ -167,7 +167,7 @@ def from_jax(jax_array, dtype=None) -> warp.array:
 
     Args:
         jax_array (jax.Array): The Jax array to convert.
-        dtype (optional): The target data type of the resulting Warp array. Defaults to the Jax array's data type mapped to a Warp data type.
+        dtype: The target data type of the resulting Warp array. Defaults to the Jax array's data type mapped to a Warp data type.
 
     Returns:
         warp.array: The converted Warp array.

--- a/warp/_src/marching_cubes.py
+++ b/warp/_src/marching_cubes.py
@@ -5,13 +5,13 @@ from __future__ import annotations
 
 from typing import Final
 
-import warp as wp
+import warp
 
 _wp_module_name_ = "warp.marching_cubes"
 
 
 # =============================================================================
-# Marching Cubes Lookup Tables (module-level for kernel access via wp.static())
+# Marching Cubes Lookup Tables (module-level for kernel access via warp.static())
 # =============================================================================
 
 # fmt: off
@@ -36,18 +36,18 @@ MC_EDGE_TO_CORNERS: Final[tuple[tuple[int, int], ...]] = (
 
 
 def marching_cubes_extract_vertices(
-    field: wp.array3d(dtype=wp.float32),
+    field: warp.array3d(dtype=warp.float32),
     threshold: float,
-    domain_bounds_lower_corner: wp.vec3,
-    grid_pos_delta: wp.vec3,
+    domain_bounds_lower_corner: warp.vec3,
+    grid_pos_delta: warp.vec3,
 ):
     """Invoke kernels to extract vertices and indices to uniquely identify them."""
     device = field.device
     nnode_x, nnode_y, nnode_z = field.shape[0], field.shape[1], field.shape[2]
 
     ### First pass: count the vertices each thread will generate
-    thread_output_count = wp.zeros(shape=(nnode_x * nnode_y * nnode_z * 3), dtype=wp.int32, device=device)
-    wp.launch(
+    thread_output_count = warp.zeros(shape=(nnode_x * nnode_y * nnode_z * 3), dtype=warp.int32, device=device)
+    warp.launch(
         extract_vertices_kernel,
         dim=(nnode_x, nnode_y, nnode_z, 3),
         inputs=[
@@ -63,8 +63,8 @@ def marching_cubes_extract_vertices(
     )
 
     ### Evaluate a cumulative sum, to compute the output index for each generated vertex
-    vertex_result_ind = wp.zeros(shape=(nnode_x * nnode_y * nnode_z * 3), dtype=wp.int32, device=device)
-    wp._src.utils.array_scan(thread_output_count, vertex_result_ind, inclusive=True)
+    vertex_result_ind = warp.zeros(shape=(nnode_x * nnode_y * nnode_z * 3), dtype=warp.int32, device=device)
+    warp._src.utils.array_scan(thread_output_count, vertex_result_ind, inclusive=True)
 
     # (synchronization point!)
     N_vert = int(vertex_result_ind[-1:].numpy()[0])
@@ -72,14 +72,14 @@ def marching_cubes_extract_vertices(
     # Allocate output arrays
     # edge_generated_vert_ind: corresponds to the the 3 positive-facing edges emanating from each node.
     #   The last boundary entries of this array will be unused, but we can't make it any smaller.
-    edge_generated_vert_ind = wp.zeros(shape=(nnode_x, nnode_y, nnode_z, 3), dtype=wp.int32, device=device)
-    verts_pos_out = wp.empty(
-        shape=N_vert, dtype=wp.vec3, device=device, requires_grad=field.requires_grad
+    edge_generated_vert_ind = warp.zeros(shape=(nnode_x, nnode_y, nnode_z, 3), dtype=warp.int32, device=device)
+    verts_pos_out = warp.empty(
+        shape=N_vert, dtype=warp.vec3, device=device, requires_grad=field.requires_grad
     )  # TODO is this the right way to decide setting requires_grad?
-    verts_is_boundary_out = wp.empty(shape=N_vert, dtype=wp.bool, device=device)
+    verts_is_boundary_out = warp.empty(shape=N_vert, dtype=warp.bool, device=device)
 
     ### Second pass: actually generate the vertices and write to the output arrays
-    wp.launch(
+    warp.launch(
         extract_vertices_kernel,
         dim=(nnode_x, nnode_y, nnode_z, 3),
         inputs=[
@@ -102,18 +102,18 @@ def marching_cubes_extract_vertices(
     return (verts_pos_out, verts_is_boundary_out, edge_generated_vert_ind)
 
 
-@wp.kernel
+@warp.kernel
 def extract_vertices_kernel(
-    values: wp.array3d(dtype=wp.float32),
-    threshold: wp.float32,
-    domain_bounds_lower_corner: wp.vec3,
-    grid_pos_delta: wp.vec3,
-    vertex_result_ind: wp.array(dtype=wp.int32),
+    values: warp.array3d(dtype=warp.float32),
+    threshold: warp.float32,
+    domain_bounds_lower_corner: warp.vec3,
+    grid_pos_delta: warp.vec3,
+    vertex_result_ind: warp.array(dtype=warp.int32),
     count_only: bool,
-    thread_output_count: wp.array(dtype=wp.int32),
-    verts_pos_out: wp.array(dtype=wp.vec3),
-    verts_is_boundary_out: wp.array(dtype=wp.bool),
-    edge_generated_vert_ind: wp.array(dtype=wp.int32, ndim=4),
+    thread_output_count: warp.array(dtype=warp.int32),
+    verts_pos_out: warp.array(dtype=warp.vec3),
+    verts_is_boundary_out: warp.array(dtype=warp.bool),
+    edge_generated_vert_ind: warp.array(dtype=warp.int32, ndim=4),
 ):
     """Kernel for vertex extraction.
 
@@ -123,13 +123,13 @@ def extract_vertices_kernel(
     second pass when count_only==False, we actually generate the vertices and write them to
     the appropriate output location.
     """
-    ti, tj, tk, t_side = wp.tid()
+    ti, tj, tk, t_side = warp.tid()
     nnode_x, nnode_y, nnode_z = values.shape[0], values.shape[1], values.shape[2]
 
     # Assemble indices
-    i_opp = ti + wp.where(t_side == 0, 1, 0)
-    j_opp = tj + wp.where(t_side == 1, 1, 0)
-    k_opp = tk + wp.where(t_side == 2, 1, 0)
+    i_opp = ti + warp.where(t_side == 0, 1, 0)
+    j_opp = tj + warp.where(t_side == 1, 1, 0)
+    k_opp = tk + warp.where(t_side == 2, 1, 0)
     out_ind = -1
 
     # Out of bounds edges off the sides of the grid
@@ -153,18 +153,18 @@ def extract_vertices_kernel(
 
             # generated vertex along the edge
             t_interp = (threshold - this_val) / (opp_val - this_val)
-            t_interp = wp.clamp(t_interp, 0.0, 1.0)
-            this_pos = domain_bounds_lower_corner + wp.vec3(
-                wp.float32(ti) * grid_pos_delta.x,
-                wp.float32(tj) * grid_pos_delta.y,
-                wp.float32(tk) * grid_pos_delta.z,
+            t_interp = warp.clamp(t_interp, 0.0, 1.0)
+            this_pos = domain_bounds_lower_corner + warp.vec3(
+                warp.float32(ti) * grid_pos_delta.x,
+                warp.float32(tj) * grid_pos_delta.y,
+                warp.float32(tk) * grid_pos_delta.z,
             )
-            opp_pos = domain_bounds_lower_corner + wp.vec3(
-                wp.float32(i_opp) * grid_pos_delta.x,
-                wp.float32(j_opp) * grid_pos_delta.y,
-                wp.float32(k_opp) * grid_pos_delta.z,
+            opp_pos = domain_bounds_lower_corner + warp.vec3(
+                warp.float32(i_opp) * grid_pos_delta.x,
+                warp.float32(j_opp) * grid_pos_delta.y,
+                warp.float32(k_opp) * grid_pos_delta.z,
             )
-            interp_pos = wp.lerp(this_pos, opp_pos, t_interp)
+            interp_pos = warp.lerp(this_pos, opp_pos, t_interp)
             this_boundary = (
                 ti == 0 or (ti + 1) == nnode_x or tj == 0 or (tj + 1) == nnode_y or tk == 0 or (tk + 1) == nnode_z
             )
@@ -187,9 +187,9 @@ def extract_vertices_kernel(
 
 
 def marching_cubes_extract_faces(
-    values: wp.array3d(dtype=wp.float32),
-    threshold: wp.float32,
-    edge_generated_vert_ind: wp.array(dtype=wp.int32, ndim=4),
+    values: warp.array3d(dtype=warp.float32),
+    threshold: warp.float32,
+    edge_generated_vert_ind: warp.array(dtype=warp.int32, ndim=4),
 ):
     """Invoke kernels to extract faces and index the appropriate vertices."""
     device = values.device
@@ -197,8 +197,8 @@ def marching_cubes_extract_faces(
     ncell_x, ncell_y, ncell_z = nnode_x - 1, nnode_y - 1, nnode_z - 1
 
     # First pass: count the number of faces each thread will generate
-    thread_output_count = wp.zeros(shape=(ncell_x * ncell_y * ncell_z), dtype=wp.int32, device=device)
-    wp.launch(
+    thread_output_count = warp.zeros(shape=(ncell_x * ncell_y * ncell_z), dtype=warp.int32, device=device)
+    warp.launch(
         extract_faces_kernel,
         dim=(ncell_x, ncell_y, ncell_z),
         inputs=[
@@ -219,17 +219,17 @@ def marching_cubes_extract_faces(
     )
 
     ### Evaluate a cumulative sum, to compute the output index for each generated face
-    face_result_ind = wp.zeros(shape=(ncell_x * ncell_y * ncell_z), dtype=wp.int32, device=device)
-    wp._src.utils.array_scan(thread_output_count, face_result_ind, inclusive=True)
+    face_result_ind = warp.zeros(shape=(ncell_x * ncell_y * ncell_z), dtype=warp.int32, device=device)
+    warp._src.utils.array_scan(thread_output_count, face_result_ind, inclusive=True)
 
     # (synchronization point!)
     N_faces = int(face_result_ind[-1:].numpy()[0])
 
     # Allocate output array
-    faces_out = wp.empty(shape=3 * N_faces, dtype=wp.int32, device=device)
+    faces_out = warp.empty(shape=3 * N_faces, dtype=warp.int32, device=device)
 
     ### Second pass: actually generate the faces and write to the output array
-    wp.launch(
+    warp.launch(
         extract_faces_kernel,
         dim=(ncell_x, ncell_y, ncell_z),
         inputs=[
@@ -254,18 +254,18 @@ def marching_cubes_extract_faces(
 
 # NOTE: differentiating this kernel does nothing, since all of its outputs are discrete, but
 # Warp issues warnings if we set enable_backward=False
-@wp.kernel
+@warp.kernel
 def extract_faces_kernel(
-    values: wp.array3d(dtype=wp.float32),
-    threshold: wp.float32,
-    edge_generated_vert_ind: wp.array(dtype=wp.int32, ndim=4),
-    face_result_ind: wp.array(dtype=wp.int32),
-    mc_case_to_tri_range_table: wp.array(dtype=wp.int32),
-    mc_tri_local_inds_table: wp.array(dtype=wp.int32),
-    mc_edge_offset_table: wp.array(dtype=wp.int32, ndim=2),
+    values: warp.array3d(dtype=warp.float32),
+    threshold: warp.float32,
+    edge_generated_vert_ind: warp.array(dtype=warp.int32, ndim=4),
+    face_result_ind: warp.array(dtype=warp.int32),
+    mc_case_to_tri_range_table: warp.array(dtype=warp.int32),
+    mc_tri_local_inds_table: warp.array(dtype=warp.int32),
+    mc_edge_offset_table: warp.array(dtype=warp.int32, ndim=2),
     count_only: bool,
-    thread_output_count: wp.array(dtype=wp.int32),
-    faces_out: wp.array(dtype=wp.int32),
+    thread_output_count: warp.array(dtype=warp.int32),
+    faces_out: warp.array(dtype=warp.int32),
 ):
     """
     Kernel for face extraction
@@ -276,7 +276,7 @@ def extract_faces_kernel(
     second pass when count_only==False, we actually generate the faces and write them to
     the appropriate output location.
     """
-    ti, tj, tk = wp.tid()
+    ti, tj, tk = warp.tid()
     nnode_x, nnode_y, nnode_z = values.shape[0], values.shape[1], values.shape[2]
     _ncell_x, ncell_y, ncell_z = nnode_x - 1, nnode_y - 1, nnode_z - 1
     ind = ti * ncell_y * ncell_z + tj * ncell_z + tk
@@ -285,17 +285,17 @@ def extract_faces_kernel(
     # NOTE: this loop should get unrolled (confirmed it does in Warp 1.4.1)
     case_code = 0
     for i_c in range(8):
-        indX = ti + wp.static(MC_CUBE_CORNER_OFFSETS[i_c][0])
-        indY = tj + wp.static(MC_CUBE_CORNER_OFFSETS[i_c][1])
-        indZ = tk + wp.static(MC_CUBE_CORNER_OFFSETS[i_c][2])
+        indX = ti + warp.static(MC_CUBE_CORNER_OFFSETS[i_c][0])
+        indY = tj + warp.static(MC_CUBE_CORNER_OFFSETS[i_c][1])
+        indZ = tk + warp.static(MC_CUBE_CORNER_OFFSETS[i_c][2])
         val = values[indX, indY, indZ]
         if val >= threshold:
-            case_code += wp.static(2**i_c)
+            case_code += warp.static(2**i_c)
 
     # Gather the range of triangles we will emit
     tri_range_start = mc_case_to_tri_range_table[case_code]
     tri_range_end = mc_case_to_tri_range_table[case_code + 1]
-    N_tri = wp.int32(tri_range_end - tri_range_start) // 3
+    N_tri = warp.int32(tri_range_end - tri_range_start) // 3
 
     # If we are just counting, record the number of triangles and move on
     if count_only:
@@ -461,32 +461,32 @@ _MC_EDGE_OFFSETS = (
 # Internal: Caching for Warp's extraction algorithm
 # =============================================================================
 
-_mc_case_to_tri_range_cache: dict[str, wp.array] = {}
-_mc_tri_local_inds_cache: dict[str, wp.array] = {}
-_mc_edge_offset_cache: dict[str, wp.array] = {}
+_mc_case_to_tri_range_cache: dict[str, warp.array] = {}
+_mc_tri_local_inds_cache: dict[str, warp.array] = {}
+_mc_edge_offset_cache: dict[str, warp.array] = {}
 
 
-def _get_mc_case_to_tri_range_table(device) -> wp.array:
+def _get_mc_case_to_tri_range_table(device) -> warp.array:
     """Lazily creates and caches the case-to-tri-range table on the target device."""
     device = str(device)
     if device not in _mc_case_to_tri_range_cache:
-        _mc_case_to_tri_range_cache[device] = wp.array(MC_CASE_TO_TRI_RANGE, dtype=wp.int32, device=device)
+        _mc_case_to_tri_range_cache[device] = warp.array(MC_CASE_TO_TRI_RANGE, dtype=warp.int32, device=device)
     return _mc_case_to_tri_range_cache[device]
 
 
-def _get_mc_tri_local_inds_table(device) -> wp.array:
+def _get_mc_tri_local_inds_table(device) -> warp.array:
     """Lazily creates and caches the tri-local-indices table on the target device."""
     device = str(device)
     if device not in _mc_tri_local_inds_cache:
-        _mc_tri_local_inds_cache[device] = wp.array(MC_TRI_LOCAL_INDICES, dtype=wp.int32, device=device)
+        _mc_tri_local_inds_cache[device] = warp.array(MC_TRI_LOCAL_INDICES, dtype=warp.int32, device=device)
     return _mc_tri_local_inds_cache[device]
 
 
-def _get_mc_edge_offset_table(device) -> wp.array:
+def _get_mc_edge_offset_table(device) -> warp.array:
     """Lazily creates and caches the edge offset table on the target device."""
     device = str(device)
     if device not in _mc_edge_offset_cache:
-        _mc_edge_offset_cache[device] = wp.array(_MC_EDGE_OFFSETS, dtype=wp.int32, device=device)
+        _mc_edge_offset_cache[device] = warp.array(_MC_EDGE_OFFSETS, dtype=warp.int32, device=device)
     return _mc_edge_offset_cache[device]
 
 
@@ -598,12 +598,12 @@ class MarchingCubes:
         self.max_tris = max_tris
 
         # Output arrays
-        self.verts: warp.array(dtype=wp.vec3f) | None = None
-        self.indices: warp.array(dtype=wp.int32) | None = None
+        self.verts: warp.array(dtype=warp.vec3f) | None = None
+        self.indices: warp.array(dtype=warp.int32) | None = None
 
         # These are unused, but retained for backwards-compatibility for code which might use them
         self.id = 0
-        self.runtime = wp._src.context.runtime
+        self.runtime = warp._src.context.runtime
         self.device = self.runtime.get_device(device)
 
     def resize(self, nx: int, ny: int, nz: int, max_verts: int = 0, max_tris: int = 0) -> None:
@@ -648,7 +648,7 @@ class MarchingCubes:
 
         verts, faces = self.extract_surface_marching_cubes(
             field=field,
-            threshold=wp.float32(threshold),
+            threshold=warp.float32(threshold),
             domain_bounds_lower_corner=self.domain_bounds_lower_corner,
             domain_bounds_upper_corner=self.domain_bounds_upper_corner,
         )
@@ -658,11 +658,11 @@ class MarchingCubes:
 
     @staticmethod
     def extract_surface_marching_cubes(
-        field: warp.array3d(dtype=wp.float32),
+        field: warp.array3d(dtype=warp.float32),
         threshold: float = 0.0,
         domain_bounds_lower_corner: warp.vec3 | tuple[float, float, float] | None = None,
         domain_bounds_upper_corner: warp.vec3 | tuple[float, float, float] | None = None,
-    ) -> tuple[warp.array(dtype=wp.vec3), warp.array(dtype=wp.int32)]:
+    ) -> tuple[warp.array(dtype=warp.vec3), warp.array(dtype=warp.int32)]:
         """Extract a triangular mesh from a 3D scalar field.
 
         This function generates an isosurface by processing the entire input ``field``.
@@ -675,8 +675,8 @@ class MarchingCubes:
         (i.e., left as ``None``), it will be assigned a default value that
         aligns the mesh with the integer indices of the input grid.
 
-        For example, setting the bounds to ``wp.vec3(0.0, 0.0, 0.0)`` and
-        ``wp.vec3(1.0, 1.0, 1.0)`` will scale the output mesh to fit
+        For example, setting the bounds to ``warp.vec3(0.0, 0.0, 0.0)`` and
+        ``warp.vec3(1.0, 1.0, 1.0)`` will scale the output mesh to fit
         within the unit cube.
 
         Args:
@@ -697,7 +697,7 @@ class MarchingCubes:
 
         Raises:
             ValueError: If ``field`` is not a 3D array or is empty.
-            TypeError: If the ``field`` data type is not ``wp.float32``.
+            TypeError: If the ``field`` data type is not ``warp.float32``.
         """
         # Do some validation
         if len(field.shape) != 3:
@@ -706,8 +706,8 @@ class MarchingCubes:
         if field.size == 0:
             raise ValueError("The 'field' array cannot be empty.")
 
-        if field.dtype != wp.float32:
-            raise TypeError(f"Expected a dtype of wp.float32 for 'field', but got {field.dtype}.")
+        if field.dtype != warp.float32:
+            raise TypeError(f"Expected a dtype of warp.float32 for 'field', but got {field.dtype}.")
 
         # Parse out dimensions, being careful to distinguish between nodes and cells
         nnode_x, nnode_y, nnode_z = field.shape[0], field.shape[1], field.shape[2]
@@ -715,21 +715,21 @@ class MarchingCubes:
 
         # Apply default policies for bounds
         if domain_bounds_lower_corner is None:
-            domain_bounds_lower_corner = wp.vec3((0.0, 0.0, 0.0))
+            domain_bounds_lower_corner = warp.vec3((0.0, 0.0, 0.0))
         if domain_bounds_upper_corner is None:
             # The default convention is to treat the nodes of the grid as having integer coordinates at 0,1,2,...
             # This means the upper-rightmost node of the grid has coordinates (nnode_x-1, nnode_y-1, nnode_z-1)
             # (which happens to be the same as the number cells, although it may be more confusing to think of it that way)
-            domain_bounds_upper_corner = wp.vec3((float(nnode_x - 1), float(nnode_y - 1), float(nnode_z - 1)))
+            domain_bounds_upper_corner = warp.vec3((float(nnode_x - 1), float(nnode_y - 1), float(nnode_z - 1)))
 
         # quietly allow tuples as input too, although this technically violates
         # the type hinting
-        domain_bounds_lower_corner = wp.vec3(domain_bounds_lower_corner)
-        domain_bounds_upper_corner = wp.vec3(domain_bounds_upper_corner)
+        domain_bounds_lower_corner = warp.vec3(domain_bounds_lower_corner)
+        domain_bounds_upper_corner = warp.vec3(domain_bounds_upper_corner)
 
         # Compute the grid spacing
         domain_width = domain_bounds_upper_corner - domain_bounds_lower_corner
-        grid_delta = wp.cw_div(domain_width, wp.vec3(ncell_x, ncell_y, ncell_z))
+        grid_delta = warp.cw_div(domain_width, warp.vec3(ncell_x, ncell_y, ncell_z))
 
         # Extract the vertices
         # The second output of this kernel is an is-boundary flag for each vertex, which

--- a/warp/_src/marching_cubes.py
+++ b/warp/_src/marching_cubes.py
@@ -36,7 +36,7 @@ MC_EDGE_TO_CORNERS: Final[tuple[tuple[int, int], ...]] = (
 
 
 def marching_cubes_extract_vertices(
-    field: warp.array3d(dtype=warp.float32),
+    field: warp.array3d[warp.float32],
     threshold: float,
     domain_bounds_lower_corner: warp.vec3,
     grid_pos_delta: warp.vec3,
@@ -104,16 +104,16 @@ def marching_cubes_extract_vertices(
 
 @warp.kernel
 def extract_vertices_kernel(
-    values: warp.array3d(dtype=warp.float32),
+    values: warp.array3d[warp.float32],
     threshold: warp.float32,
     domain_bounds_lower_corner: warp.vec3,
     grid_pos_delta: warp.vec3,
-    vertex_result_ind: warp.array(dtype=warp.int32),
+    vertex_result_ind: warp.array[warp.int32],
     count_only: bool,
-    thread_output_count: warp.array(dtype=warp.int32),
-    verts_pos_out: warp.array(dtype=warp.vec3),
-    verts_is_boundary_out: warp.array(dtype=warp.bool),
-    edge_generated_vert_ind: warp.array(dtype=warp.int32, ndim=4),
+    thread_output_count: warp.array[warp.int32],
+    verts_pos_out: warp.array[warp.vec3],
+    verts_is_boundary_out: warp.array[warp.bool],
+    edge_generated_vert_ind: warp.array4d[warp.int32],
 ):
     """Kernel for vertex extraction.
 
@@ -187,9 +187,9 @@ def extract_vertices_kernel(
 
 
 def marching_cubes_extract_faces(
-    values: warp.array3d(dtype=warp.float32),
+    values: warp.array3d[warp.float32],
     threshold: warp.float32,
-    edge_generated_vert_ind: warp.array(dtype=warp.int32, ndim=4),
+    edge_generated_vert_ind: warp.array4d[warp.int32],
 ):
     """Invoke kernels to extract faces and index the appropriate vertices."""
     device = values.device
@@ -256,16 +256,16 @@ def marching_cubes_extract_faces(
 # Warp issues warnings if we set enable_backward=False
 @warp.kernel
 def extract_faces_kernel(
-    values: warp.array3d(dtype=warp.float32),
+    values: warp.array3d[warp.float32],
     threshold: warp.float32,
-    edge_generated_vert_ind: warp.array(dtype=warp.int32, ndim=4),
-    face_result_ind: warp.array(dtype=warp.int32),
-    mc_case_to_tri_range_table: warp.array(dtype=warp.int32),
-    mc_tri_local_inds_table: warp.array(dtype=warp.int32),
-    mc_edge_offset_table: warp.array(dtype=warp.int32, ndim=2),
+    edge_generated_vert_ind: warp.array4d[warp.int32],
+    face_result_ind: warp.array[warp.int32],
+    mc_case_to_tri_range_table: warp.array[warp.int32],
+    mc_tri_local_inds_table: warp.array[warp.int32],
+    mc_edge_offset_table: warp.array2d[warp.int32],
     count_only: bool,
-    thread_output_count: warp.array(dtype=warp.int32),
-    faces_out: warp.array(dtype=warp.int32),
+    thread_output_count: warp.array[warp.int32],
+    faces_out: warp.array[warp.int32],
 ):
     """
     Kernel for face extraction
@@ -598,8 +598,8 @@ class MarchingCubes:
         self.max_tris = max_tris
 
         # Output arrays
-        self.verts: warp.array(dtype=warp.vec3f) | None = None
-        self.indices: warp.array(dtype=warp.int32) | None = None
+        self.verts: warp.array[warp.vec3f] | None = None
+        self.indices: warp.array[warp.int32] | None = None
 
         # These are unused, but retained for backwards-compatibility for code which might use them
         self.id = 0
@@ -624,7 +624,7 @@ class MarchingCubes:
         self.ny = ny
         self.nz = nz
 
-    def surface(self, field: warp.array(dtype=float, ndim=3), threshold: float) -> None:
+    def surface(self, field: warp.array3d[float], threshold: float) -> None:
         """Compute a 2D surface mesh of a given isosurface from a 3D scalar field.
 
         This method is a convenience wrapper that calls the core static method
@@ -658,11 +658,11 @@ class MarchingCubes:
 
     @staticmethod
     def extract_surface_marching_cubes(
-        field: warp.array3d(dtype=warp.float32),
+        field: warp.array3d[warp.float32],
         threshold: float = 0.0,
         domain_bounds_lower_corner: warp.vec3 | tuple[float, float, float] | None = None,
         domain_bounds_upper_corner: warp.vec3 | tuple[float, float, float] | None = None,
-    ) -> tuple[warp.array(dtype=warp.vec3), warp.array(dtype=warp.int32)]:
+    ) -> tuple[warp.array[warp.vec3], warp.array[warp.int32]]:
         """Extract a triangular mesh from a 3D scalar field.
 
         This function generates an isosurface by processing the entire input ``field``.

--- a/warp/_src/marching_cubes.py
+++ b/warp/_src/marching_cubes.py
@@ -563,7 +563,7 @@ class MarchingCubes:
         nz: int,
         max_verts: int = 0,
         max_tris: int = 0,
-        device: wp.DeviceLike = None,
+        device: warp.DeviceLike = None,
         domain_bounds_lower_corner=None,
         domain_bounds_upper_corner=None,
     ):
@@ -598,8 +598,8 @@ class MarchingCubes:
         self.max_tris = max_tris
 
         # Output arrays
-        self.verts: wp.array(dtype=wp.vec3f) | None = None
-        self.indices: wp.array(dtype=wp.int32) | None = None
+        self.verts: warp.array(dtype=wp.vec3f) | None = None
+        self.indices: warp.array(dtype=wp.int32) | None = None
 
         # These are unused, but retained for backwards-compatibility for code which might use them
         self.id = 0
@@ -624,7 +624,7 @@ class MarchingCubes:
         self.ny = ny
         self.nz = nz
 
-    def surface(self, field: wp.array(dtype=float, ndim=3), threshold: float) -> None:
+    def surface(self, field: warp.array(dtype=float, ndim=3), threshold: float) -> None:
         """Compute a 2D surface mesh of a given isosurface from a 3D scalar field.
 
         This method is a convenience wrapper that calls the core static method
@@ -658,11 +658,11 @@ class MarchingCubes:
 
     @staticmethod
     def extract_surface_marching_cubes(
-        field: wp.array3d(dtype=wp.float32),
+        field: warp.array3d(dtype=wp.float32),
         threshold: float = 0.0,
-        domain_bounds_lower_corner: wp.vec3 | tuple[float, float, float] | None = None,
-        domain_bounds_upper_corner: wp.vec3 | tuple[float, float, float] | None = None,
-    ) -> tuple[wp.array(dtype=wp.vec3), wp.array(dtype=wp.int32)]:
+        domain_bounds_lower_corner: warp.vec3 | tuple[float, float, float] | None = None,
+        domain_bounds_upper_corner: warp.vec3 | tuple[float, float, float] | None = None,
+    ) -> tuple[warp.array(dtype=wp.vec3), warp.array(dtype=wp.int32)]:
         """Extract a triangular mesh from a 3D scalar field.
 
         This function generates an isosurface by processing the entire input ``field``.

--- a/warp/_src/math.py
+++ b/warp/_src/math.py
@@ -498,7 +498,7 @@ def create_transform_from_matrix_func(dtype):
         * :math:`p` is the 3D position vector :math:`[p_x, p_y, p_z]` extracted from the input matrix.
 
         Args:
-            mat (Matrix[Float, 4, 4]): Matrix to convert.
+            mat (Matrix[Float, Literal[4], Literal[4]]): Matrix to convert.
 
         Returns:
             Transformation[Float]: The transformation.
@@ -548,7 +548,7 @@ def create_transform_to_matrix_func(dtype):
             xform (Transformation[Float]): Transformation to convert.
 
         Returns:
-            Matrix[Float, 4, 4]: The matrix.
+            Matrix[Float, Literal[4], Literal[4]]: The matrix.
         """
         p = warp.transform_get_translation(xform)
         q = warp.transform_get_rotation(xform)
@@ -602,12 +602,12 @@ def create_transform_compose_func(dtype):
         * :math:`s` is the input 3D scale vector :math:`[s_x, s_y, s_z]`.
 
         Args:
-            position (Vector[Float, 3]): The 3D position vector.
+            position (Vector[Float, Literal[3]]): The 3D position vector.
             rotation (Quaternion[Float]): The quaternion orientation.
-            scale (Vector[Float, 3]): The 3D scale vector.
+            scale (Vector[Float, Literal[3]]): The 3D scale vector.
 
         Returns:
-            Matrix[Float, 4, 4]: The transformation matrix.
+            Matrix[Float, Literal[4], Literal[4]]: The transformation matrix.
         """
         R = warp.quat_to_matrix(rotation)
         # fmt: off
@@ -660,10 +660,10 @@ def create_transform_decompose_func(dtype):
         * :math:`s` is the 3D scale vector :math:`[s_x, s_y, s_z]` extracted from the input matrix.
 
         Args:
-            m (Matrix[Float, 4, 4]): The matrix to decompose.
+            m (Matrix[Float, Literal[4], Literal[4]]): The matrix to decompose.
 
         Returns:
-            Tuple[Vector[Float, 3], Quaternion[Float], Vector[Float, 3]]: A tuple containing the position vector, quaternion orientation, and scale vector.
+            Tuple[Vector[Float, Literal[3]], Quaternion[Float], Vector[Float, Literal[3]]]: A tuple containing the position vector, quaternion orientation, and scale vector.
         """
         # extract position
         position = vec3(m[0, 3], m[1, 3], m[2, 3])

--- a/warp/_src/math.py
+++ b/warp/_src/math.py
@@ -3,7 +3,7 @@
 
 from typing import Any
 
-import warp as wp
+import warp
 
 """
 Math helper functions for vector norms, quaternions, and transforms.
@@ -32,7 +32,7 @@ __all__ = [
 ]
 
 
-@wp.func
+@warp.func
 def norm_l1(v: Any) -> float:
     """Compute the L1 norm of a vector v.
 
@@ -46,11 +46,11 @@ def norm_l1(v: Any) -> float:
     """
     n = float(0.0)
     for i in range(len(v)):
-        n += wp.abs(v[i])
+        n += warp.abs(v[i])
     return n
 
 
-@wp.func
+@warp.func
 def norm_l2(v: Any) -> float:
     """Compute the L2 norm of a vector v.
 
@@ -62,10 +62,10 @@ def norm_l2(v: Any) -> float:
     Returns:
         float: The L2 norm of the vector.
     """
-    return wp.length(v)
+    return warp.length(v)
 
 
-@wp.func
+@warp.func
 def norm_huber(v: Any, delta: float = 1.0) -> float:
     """Compute the Huber norm of a vector v with a given delta.
 
@@ -82,13 +82,13 @@ def norm_huber(v: Any, delta: float = 1.0) -> float:
     Returns:
         float: The Huber norm of the vector.
     """
-    a = wp.dot(v, v)
+    a = warp.dot(v, v)
     if a <= delta * delta:
         return 0.5 * a
-    return delta * (wp.sqrt(a) - 0.5 * delta)
+    return delta * (warp.sqrt(a) - 0.5 * delta)
 
 
-@wp.func
+@warp.func
 def norm_pseudo_huber(v: Any, delta: float = 1.0) -> float:
     """Compute the "pseudo" Huber norm of a vector v with a given delta.
 
@@ -105,11 +105,11 @@ def norm_pseudo_huber(v: Any, delta: float = 1.0) -> float:
     Returns:
         float: The Huber norm of the vector.
     """
-    a = wp.dot(v, v)
-    return delta * wp.sqrt(1.0 + a / (delta * delta))
+    a = warp.dot(v, v)
+    return delta * warp.sqrt(1.0 + a / (delta * delta))
 
 
-@wp.func
+@warp.func
 def smooth_normalize(v: Any, delta: float = 1.0) -> Any:
     """Normalize a vector using the pseudo-Huber norm.
 
@@ -128,8 +128,8 @@ def smooth_normalize(v: Any, delta: float = 1.0) -> Any:
     return v / norm_pseudo_huber(v, delta)
 
 
-@wp.func
-def velocity_at_point(qd: wp.spatial_vector, r: wp.vec3) -> wp.vec3:
+@warp.func
+def velocity_at_point(qd: "warp.spatial_vector", r: "warp.vec3") -> "warp.vec3":
     """Evaluate the linear velocity of an offset point on a rigid body.
 
     Given a spatial twist ``qd = (w, v)`` and a point offset ``r`` from the twist
@@ -143,13 +143,13 @@ def velocity_at_point(qd: wp.spatial_vector, r: wp.vec3) -> wp.vec3:
         r: Point position relative to the same frame origin.
 
     Returns:
-        wp.vec3: Linear velocity of the point.
+        warp.vec3: Linear velocity of the point.
     """
-    return wp.spatial_bottom(qd) + wp.cross(wp.spatial_top(qd), r)
+    return warp.spatial_bottom(qd) + warp.cross(warp.spatial_top(qd), r)
 
 
-@wp.func
-def quat_twist(axis: wp.vec3, q: wp.quat) -> wp.quat:
+@warp.func
+def quat_twist(axis: "warp.vec3", q: "warp.quat") -> "warp.quat":
     """Extract the twist quaternion of ``q`` around ``axis``.
 
     This performs a swing-twist decomposition and returns the component of
@@ -160,16 +160,16 @@ def quat_twist(axis: wp.vec3, q: wp.quat) -> wp.quat:
         q: Input quaternion in ``(x, y, z, w)`` layout.
 
     Returns:
-        wp.quat: Unit twist quaternion.
+        warp.quat: Unit twist quaternion.
     """
-    a = wp.vec3(q[0], q[1], q[2])
-    proj = wp.dot(a, axis)
+    a = warp.vec3(q[0], q[1], q[2])
+    proj = warp.dot(a, axis)
     a = proj * axis
-    return wp.normalize(wp.quat(a[0], a[1], a[2], q[3]))
+    return warp.normalize(warp.quat(a[0], a[1], a[2], q[3]))
 
 
-@wp.func
-def quat_twist_angle(axis: wp.vec3, q: wp.quat) -> float:
+@warp.func
+def quat_twist_angle(axis: "warp.vec3", q: "warp.quat") -> float:
     """Return the twist magnitude of ``q`` around ``axis``.
 
     This returns an unsigned twist magnitude. For canonicalized quaternions
@@ -183,11 +183,11 @@ def quat_twist_angle(axis: wp.vec3, q: wp.quat) -> float:
     Returns:
         float: Twist angle in radians in ``[0, pi]`` for canonicalized inputs.
     """
-    return 2.0 * wp.acos(quat_twist(axis, q)[3])
+    return 2.0 * warp.acos(quat_twist(axis, q)[3])
 
 
-@wp.func
-def quat_to_rpy(q: wp.quat) -> wp.vec3:
+@warp.func
+def quat_to_rpy(q: "warp.quat") -> "warp.vec3":
     """Convert a quaternion to roll-pitch-yaw angles (ZYX convention).
 
     The output is ``(roll, pitch, yaw)`` in radians using extrinsic rotations
@@ -197,7 +197,7 @@ def quat_to_rpy(q: wp.quat) -> wp.vec3:
         q: Input quaternion in ``(x, y, z, w)`` order.
 
     Returns:
-        wp.vec3: ``(roll, pitch, yaw)`` in radians.
+        warp.vec3: ``(roll, pitch, yaw)`` in radians.
     """
 
     x = q[0]
@@ -206,21 +206,21 @@ def quat_to_rpy(q: wp.quat) -> wp.vec3:
     w = q[3]
     t0 = 2.0 * (w * x + y * z)
     t1 = 1.0 - 2.0 * (x * x + y * y)
-    roll_x = wp.atan2(t0, t1)
+    roll_x = warp.atan2(t0, t1)
 
     t2 = 2.0 * (w * y - z * x)
-    t2 = wp.clamp(t2, -1.0, 1.0)
-    pitch_y = wp.asin(t2)
+    t2 = warp.clamp(t2, -1.0, 1.0)
+    pitch_y = warp.asin(t2)
 
     t3 = 2.0 * (w * z + x * y)
     t4 = 1.0 - 2.0 * (y * y + z * z)
-    yaw_z = wp.atan2(t3, t4)
+    yaw_z = warp.atan2(t3, t4)
 
-    return wp.vec3(roll_x, pitch_y, yaw_z)
+    return warp.vec3(roll_x, pitch_y, yaw_z)
 
 
-@wp.func
-def quat_to_euler(q: wp.quat, i: int, j: int, k: int) -> wp.vec3:
+@warp.func
+def quat_to_euler(q: "warp.quat", i: int, j: int, k: int) -> "warp.vec3":
     """Convert a quaternion into Euler angles for an axis sequence.
 
     The integers ``i``, ``j``, and ``k`` are axis indices in ``{0, 1, 2}``
@@ -248,7 +248,7 @@ def quat_to_euler(q: wp.quat, i: int, j: int, k: int) -> wp.vec3:
         k: Index of the third axis.
 
     Returns:
-        wp.vec3: Euler angles in radians.
+        warp.vec3: Euler angles in radians.
     """
     # The conversion formula below is derived for scalar-first quaternions
     # q = (w, x, y, z). Warp stores quaternions as (x, y, z, w), so remap
@@ -309,20 +309,20 @@ def quat_to_euler(q: wp.quat, i: int, j: int, k: int) -> wp.vec3:
         b += qk * e
         c += q0
         d -= qi
-    t2 = wp.acos(2.0 * (a * a + b * b) / (a * a + b * b + c * c + d * d) - 1.0)
-    tp = wp.atan2(b, a)
-    tm = wp.atan2(d, c)
+    t2 = warp.acos(2.0 * (a * a + b * b) / (a * a + b * b + c * c + d * d) - 1.0)
+    tp = warp.atan2(b, a)
+    tm = warp.atan2(d, c)
     t1 = 0.0
     t3 = 0.0
-    if wp.abs(t2) < 1e-6:
+    if warp.abs(t2) < 1e-6:
         t3 = 2.0 * tp - t1
-    elif wp.abs(t2 - wp.pi) < 1e-6:
+    elif warp.abs(t2 - warp.pi) < 1e-6:
         t3 = 2.0 * tm + t1
     else:
         t1 = tp - tm
         t3 = tp + tm
     if not_proper:
-        t2 -= wp.HALF_PI
+        t2 -= warp.HALF_PI
         t3 *= e
 
     # Place the solved angles back into (x, y, z) by axis index.
@@ -352,11 +352,11 @@ def quat_to_euler(q: wp.quat, i: int, j: int, k: int) -> wp.vec3:
     else:
         ez = t3
 
-    return wp.vec3(ex, ey, ez)
+    return warp.vec3(ex, ey, ez)
 
 
-@wp.func
-def quat_from_euler(e: wp.vec3, i: int, j: int, k: int) -> wp.quat:
+@warp.func
+def quat_from_euler(e: "warp.vec3", i: int, j: int, k: int) -> "warp.quat":
     """Construct a quaternion from Euler angles and an axis sequence.
 
     Args:
@@ -371,7 +371,7 @@ def quat_from_euler(e: wp.vec3, i: int, j: int, k: int) -> wp.quat:
         :func:`quat_to_euler`.
 
     Returns:
-        wp.quat: Quaternion in ``(x, y, z, w)`` layout.
+        warp.quat: Quaternion in ``(x, y, z, w)`` layout.
     """
     ei = e[i]
     ej = e[j]
@@ -381,45 +381,45 @@ def quat_from_euler(e: wp.vec3, i: int, j: int, k: int) -> wp.quat:
     hj = 0.5 * ej
     hk = 0.5 * ek
 
-    qi = wp.quat(0.0, 0.0, 0.0, 1.0)
-    qj = wp.quat(0.0, 0.0, 0.0, 1.0)
-    qk = wp.quat(0.0, 0.0, 0.0, 1.0)
+    qi = warp.quat(0.0, 0.0, 0.0, 1.0)
+    qj = warp.quat(0.0, 0.0, 0.0, 1.0)
+    qk = warp.quat(0.0, 0.0, 0.0, 1.0)
 
-    si = wp.sin(hi)
-    sj = wp.sin(hj)
-    sk = wp.sin(hk)
-    ci = wp.cos(hi)
-    cj = wp.cos(hj)
-    ck = wp.cos(hk)
+    si = warp.sin(hi)
+    sj = warp.sin(hj)
+    sk = warp.sin(hk)
+    ci = warp.cos(hi)
+    cj = warp.cos(hj)
+    ck = warp.cos(hk)
 
     if i == 0:
-        qi = wp.quat(si, 0.0, 0.0, ci)
+        qi = warp.quat(si, 0.0, 0.0, ci)
     elif i == 1:
-        qi = wp.quat(0.0, si, 0.0, ci)
+        qi = warp.quat(0.0, si, 0.0, ci)
     else:
-        qi = wp.quat(0.0, 0.0, si, ci)
+        qi = warp.quat(0.0, 0.0, si, ci)
 
     if j == 0:
-        qj = wp.quat(sj, 0.0, 0.0, cj)
+        qj = warp.quat(sj, 0.0, 0.0, cj)
     elif j == 1:
-        qj = wp.quat(0.0, sj, 0.0, cj)
+        qj = warp.quat(0.0, sj, 0.0, cj)
     else:
-        qj = wp.quat(0.0, 0.0, sj, cj)
+        qj = warp.quat(0.0, 0.0, sj, cj)
 
     if k == 0:
-        qk = wp.quat(sk, 0.0, 0.0, ck)
+        qk = warp.quat(sk, 0.0, 0.0, ck)
     elif k == 1:
-        qk = wp.quat(0.0, sk, 0.0, ck)
+        qk = warp.quat(0.0, sk, 0.0, ck)
     else:
-        qk = wp.quat(0.0, 0.0, sk, ck)
+        qk = warp.quat(0.0, 0.0, sk, ck)
 
     # For extrinsic rotations about fixed axes i -> j -> k, quaternion
     # composition is q = q_k * q_j * q_i.
-    return wp.mul(qk, wp.mul(qj, qi))
+    return warp.mul(qk, warp.mul(qj, qi))
 
 
-@wp.func
-def transform_twist(t: wp.transform, x: wp.spatial_vector) -> wp.spatial_vector:
+@warp.func
+def transform_twist(t: "warp.transform", x: "warp.spatial_vector") -> "warp.spatial_vector":
     """Transform a spatial twist between coordinate frames.
 
     For transform ``t = (R, p)`` and twist ``x = (w, v)``, the mapped twist is:
@@ -432,23 +432,23 @@ def transform_twist(t: wp.transform, x: wp.spatial_vector) -> wp.spatial_vector:
         x: Spatial twist ``(angular, linear)`` expressed in the source frame.
 
     Returns:
-        wp.spatial_vector: Twist expressed in the destination frame.
+        warp.spatial_vector: Twist expressed in the destination frame.
     """
 
-    q = wp.transform_get_rotation(t)
-    p = wp.transform_get_translation(t)
+    q = warp.transform_get_rotation(t)
+    p = warp.transform_get_translation(t)
 
-    w = wp.spatial_top(x)
-    v = wp.spatial_bottom(x)
+    w = warp.spatial_top(x)
+    v = warp.spatial_bottom(x)
 
-    w = wp.quat_rotate(q, w)
-    v = wp.quat_rotate(q, v) + wp.cross(p, w)
+    w = warp.quat_rotate(q, w)
+    v = warp.quat_rotate(q, v) + warp.cross(p, w)
 
-    return wp.spatial_vector(w, v)
+    return warp.spatial_vector(w, v)
 
 
-@wp.func
-def transform_wrench(t: wp.transform, x: wp.spatial_vector) -> wp.spatial_vector:
+@warp.func
+def transform_wrench(t: "warp.transform", x: "warp.spatial_vector") -> "warp.spatial_vector":
     """Transform a spatial wrench between coordinate frames.
 
     For transform ``t = (R, p)`` and wrench ``x = (tau, f)``, the mapped wrench is:
@@ -461,25 +461,25 @@ def transform_wrench(t: wp.transform, x: wp.spatial_vector) -> wp.spatial_vector
         x: Spatial wrench ``(torque, force)`` expressed in the source frame.
 
     Returns:
-        wp.spatial_vector: Wrench expressed in the destination frame.
+        warp.spatial_vector: Wrench expressed in the destination frame.
     """
 
-    q = wp.transform_get_rotation(t)
-    p = wp.transform_get_translation(t)
+    q = warp.transform_get_rotation(t)
+    p = warp.transform_get_translation(t)
 
-    tau = wp.spatial_top(x)
-    f = wp.spatial_bottom(x)
+    tau = warp.spatial_top(x)
+    f = warp.spatial_bottom(x)
 
-    f = wp.quat_rotate(q, f)
-    tau = wp.quat_rotate(q, tau) + wp.cross(p, f)
+    f = warp.quat_rotate(q, f)
+    tau = warp.quat_rotate(q, tau) + warp.cross(p, f)
 
-    return wp.spatial_vector(tau, f)
+    return warp.spatial_vector(tau, f)
 
 
 def create_transform_from_matrix_func(dtype):
-    mat44 = wp._src.types.matrix((4, 4), dtype)
-    vec3 = wp._src.types.vector(3, dtype)
-    transform = wp._src.types.transformation(dtype)
+    mat44 = warp._src.types.matrix((4, 4), dtype)
+    vec3 = warp._src.types.vector(3, dtype)
+    transform = warp._src.types.transformation(dtype)
 
     def transform_from_matrix(mat: mat44) -> transform:
         """Construct a transformation from a 4x4 matrix.
@@ -504,29 +504,29 @@ def create_transform_from_matrix_func(dtype):
             Transformation[Float]: The transformation.
         """
         p = vec3(mat[0][3], mat[1][3], mat[2][3])
-        q = wp.quat_from_matrix(mat)
+        q = warp.quat_from_matrix(mat)
         return transform(p, q)
 
     return transform_from_matrix
 
 
-transform_from_matrix = wp.func(
-    create_transform_from_matrix_func(wp.float32),
+transform_from_matrix = warp.func(
+    create_transform_from_matrix_func(warp.float32),
     name="transform_from_matrix",
 )
-wp.func(
-    create_transform_from_matrix_func(wp.float16),
+warp.func(
+    create_transform_from_matrix_func(warp.float16),
     name="transform_from_matrix",
 )
-wp.func(
-    create_transform_from_matrix_func(wp.float64),
+warp.func(
+    create_transform_from_matrix_func(warp.float64),
     name="transform_from_matrix",
 )
 
 
 def create_transform_to_matrix_func(dtype):
-    mat44 = wp._src.types.matrix((4, 4), dtype)
-    transform = wp._src.types.transformation(dtype)
+    mat44 = warp._src.types.matrix((4, 4), dtype)
+    transform = warp._src.types.transformation(dtype)
 
     def transform_to_matrix(xform: transform) -> mat44:
         """Convert a transformation to a 4x4 matrix.
@@ -550,9 +550,9 @@ def create_transform_to_matrix_func(dtype):
         Returns:
             Matrix[Float, 4, 4]: The matrix.
         """
-        p = wp.transform_get_translation(xform)
-        q = wp.transform_get_rotation(xform)
-        rot = wp.quat_to_matrix(q)
+        p = warp.transform_get_translation(xform)
+        q = warp.transform_get_rotation(xform)
+        rot = warp.quat_to_matrix(q)
         # fmt: off
         return mat44(
             rot[0][0], rot[0][1], rot[0][2], p[0],
@@ -565,24 +565,24 @@ def create_transform_to_matrix_func(dtype):
     return transform_to_matrix
 
 
-transform_to_matrix = wp.func(
-    create_transform_to_matrix_func(wp.float32),
+transform_to_matrix = warp.func(
+    create_transform_to_matrix_func(warp.float32),
     name="transform_to_matrix",
 )
-wp.func(
-    create_transform_to_matrix_func(wp.float16),
+warp.func(
+    create_transform_to_matrix_func(warp.float16),
     name="transform_to_matrix",
 )
-wp.func(
-    create_transform_to_matrix_func(wp.float64),
+warp.func(
+    create_transform_to_matrix_func(warp.float64),
     name="transform_to_matrix",
 )
 
 
 def create_transform_compose_func(dtype):
-    mat44 = wp._src.types.matrix((4, 4), dtype)
-    quat = wp._src.types.quaternion(dtype)
-    vec3 = wp._src.types.vector(3, dtype)
+    mat44 = warp._src.types.matrix((4, 4), dtype)
+    quat = warp._src.types.quaternion(dtype)
+    vec3 = warp._src.types.vector(3, dtype)
 
     def transform_compose(position: vec3, rotation: quat, scale: vec3):
         """Compose a 4x4 transformation matrix from a 3D position, quaternion orientation, and 3D scale.
@@ -609,7 +609,7 @@ def create_transform_compose_func(dtype):
         Returns:
             Matrix[Float, 4, 4]: The transformation matrix.
         """
-        R = wp.quat_to_matrix(rotation)
+        R = warp.quat_to_matrix(rotation)
         # fmt: off
         return mat44(
             scale[0] * R[0,0], scale[1] * R[0,1], scale[2] * R[0,2], position[0],
@@ -622,24 +622,24 @@ def create_transform_compose_func(dtype):
     return transform_compose
 
 
-transform_compose = wp.func(
-    create_transform_compose_func(wp.float32),
+transform_compose = warp.func(
+    create_transform_compose_func(warp.float32),
     name="transform_compose",
 )
-wp.func(
-    create_transform_compose_func(wp.float16),
+warp.func(
+    create_transform_compose_func(warp.float16),
     name="transform_compose",
 )
-wp.func(
-    create_transform_compose_func(wp.float64),
+warp.func(
+    create_transform_compose_func(warp.float64),
     name="transform_compose",
 )
 
 
 def create_transform_decompose_func(dtype):
-    mat44 = wp._src.types.matrix((4, 4), dtype)
-    vec3 = wp._src.types.vector(3, dtype)
-    mat33 = wp._src.types.matrix((3, 3), dtype)
+    mat44 = warp._src.types.matrix((4, 4), dtype)
+    vec3 = warp._src.types.vector(3, dtype)
+    mat33 = warp._src.types.matrix((3, 3), dtype)
     zero = dtype(0.0)
 
     def transform_decompose(m: mat44):
@@ -672,9 +672,9 @@ def create_transform_decompose_func(dtype):
         r10, r11, r12 = m[1, 0], m[1, 1], m[1, 2]
         r20, r21, r22 = m[2, 0], m[2, 1], m[2, 2]
         # get scale magnitudes
-        sx = wp.sqrt(r00 * r00 + r10 * r10 + r20 * r20)
-        sy = wp.sqrt(r01 * r01 + r11 * r11 + r21 * r21)
-        sz = wp.sqrt(r02 * r02 + r12 * r12 + r22 * r22)
+        sx = warp.sqrt(r00 * r00 + r10 * r10 + r20 * r20)
+        sy = warp.sqrt(r01 * r01 + r11 * r11 + r21 * r21)
+        sz = warp.sqrt(r02 * r02 + r12 * r12 + r22 * r22)
         # normalize rotation matrix components
         if sx != zero:
             r00 /= sx
@@ -689,7 +689,7 @@ def create_transform_decompose_func(dtype):
             r12 /= sz
             r22 /= sz
         # extract rotation (quaternion)
-        rotation = wp.quat_from_matrix(mat33(r00, r01, r02, r10, r11, r12, r20, r21, r22))
+        rotation = warp.quat_from_matrix(mat33(r00, r01, r02, r10, r11, r12, r20, r21, r22))
         # extract scale
         scale = vec3(sx, sy, sz)
         return position, rotation, scale
@@ -697,87 +697,87 @@ def create_transform_decompose_func(dtype):
     return transform_decompose
 
 
-transform_decompose = wp.func(
-    create_transform_decompose_func(wp.float32),
+transform_decompose = warp.func(
+    create_transform_decompose_func(warp.float32),
     name="transform_decompose",
 )
-wp.func(
-    create_transform_decompose_func(wp.float16),
+warp.func(
+    create_transform_decompose_func(warp.float16),
     name="transform_decompose",
 )
-wp.func(
-    create_transform_decompose_func(wp.float64),
+warp.func(
+    create_transform_decompose_func(warp.float64),
     name="transform_decompose",
 )
 
 
 # register API functions so they appear in the documentation
 
-wp._src.context.register_api_function(
+warp._src.context.register_api_function(
     norm_l1,
     group="Vector Math",
 )
-wp._src.context.register_api_function(
+warp._src.context.register_api_function(
     norm_l2,
     group="Vector Math",
 )
-wp._src.context.register_api_function(
+warp._src.context.register_api_function(
     norm_huber,
     group="Vector Math",
 )
-wp._src.context.register_api_function(
+warp._src.context.register_api_function(
     norm_pseudo_huber,
     group="Vector Math",
 )
-wp._src.context.register_api_function(
+warp._src.context.register_api_function(
     smooth_normalize,
     group="Vector Math",
 )
-wp._src.context.register_api_function(
+warp._src.context.register_api_function(
     quat_from_euler,
     group="Quaternion Math",
 )
-wp._src.context.register_api_function(
+warp._src.context.register_api_function(
     quat_to_euler,
     group="Quaternion Math",
 )
-wp._src.context.register_api_function(
+warp._src.context.register_api_function(
     quat_to_rpy,
     group="Quaternion Math",
 )
-wp._src.context.register_api_function(
+warp._src.context.register_api_function(
     quat_twist,
     group="Quaternion Math",
 )
-wp._src.context.register_api_function(
+warp._src.context.register_api_function(
     quat_twist_angle,
     group="Quaternion Math",
 )
-wp._src.context.register_api_function(
+warp._src.context.register_api_function(
     velocity_at_point,
     group="Spatial Math",
 )
-wp._src.context.register_api_function(
+warp._src.context.register_api_function(
     transform_from_matrix,
     group="Transformations",
 )
-wp._src.context.register_api_function(
+warp._src.context.register_api_function(
     transform_to_matrix,
     group="Transformations",
 )
-wp._src.context.register_api_function(
+warp._src.context.register_api_function(
     transform_compose,
     group="Transformations",
 )
-wp._src.context.register_api_function(
+warp._src.context.register_api_function(
     transform_decompose,
     group="Transformations",
 )
-wp._src.context.register_api_function(
+warp._src.context.register_api_function(
     transform_twist,
     group="Spatial Math",
 )
-wp._src.context.register_api_function(
+warp._src.context.register_api_function(
     transform_wrench,
     group="Spatial Math",
 )

--- a/warp/_src/paddle.py
+++ b/warp/_src/paddle.py
@@ -208,7 +208,7 @@ dtype_is_compatible.compatible_sets = None
 # wrap a paddle tensor to a wp array, data is not copied
 def from_paddle(
     t: paddle.Tensor,
-    dtype: paddle.dtype | None = None,
+    dtype: type | None = None,
     requires_grad: bool | None = None,
     grad: paddle.Tensor | None = None,
     return_ctype: bool = False,
@@ -217,10 +217,10 @@ def from_paddle(
 
     Args:
         t (paddle.Tensor): The paddle tensor to wrap.
-        dtype (warp.dtype): The target data type of the resulting Warp array. Defaults to the tensor value type mapped to a Warp array value type.
+        dtype: The target data type of the resulting Warp array. Defaults to the tensor value type mapped to a Warp array value type.
         requires_grad (bool): Whether the resulting array should wrap the tensor's gradient, if it exists (the grad tensor will be allocated otherwise). Defaults to the tensor's `requires_grad` value.
         grad (paddle.Tensor): The grad attached to given tensor. Defaults to None.
-        return_ctype (bool): Whether to return a low-level array descriptor instead of a ``wp.array`` object (faster).  The descriptor can be passed to Warp kernels.
+        return_ctype (bool): Whether to return a low-level array descriptor instead of a ``warp.array`` object (faster).  The descriptor can be passed to Warp kernels.
 
     Returns:
         warp.array: The wrapped array or array descriptor.

--- a/warp/_src/paddle.py
+++ b/warp/_src/paddle.py
@@ -217,10 +217,10 @@ def from_paddle(
 
     Args:
         t (paddle.Tensor): The paddle tensor to wrap.
-        dtype (warp.dtype, optional): The target data type of the resulting Warp array. Defaults to the tensor value type mapped to a Warp array value type.
-        requires_grad (bool, optional): Whether the resulting array should wrap the tensor's gradient, if it exists (the grad tensor will be allocated otherwise). Defaults to the tensor's `requires_grad` value.
-        grad (paddle.Tensor, optional): The grad attached to given tensor. Defaults to None.
-        return_ctype (bool, optional): Whether to return a low-level array descriptor instead of a ``wp.array`` object (faster).  The descriptor can be passed to Warp kernels.
+        dtype (warp.dtype): The target data type of the resulting Warp array. Defaults to the tensor value type mapped to a Warp array value type.
+        requires_grad (bool): Whether the resulting array should wrap the tensor's gradient, if it exists (the grad tensor will be allocated otherwise). Defaults to the tensor's `requires_grad` value.
+        grad (paddle.Tensor): The grad attached to given tensor. Defaults to None.
+        return_ctype (bool): Whether to return a low-level array descriptor instead of a ``wp.array`` object (faster).  The descriptor can be passed to Warp kernels.
 
     Returns:
         warp.array: The wrapped array or array descriptor.

--- a/warp/_src/render/render_opengl.py
+++ b/warp/_src/render/render_opengl.py
@@ -264,13 +264,13 @@ void main() {
 
 @warp.kernel
 def update_vbo_transforms(
-    instance_id: warp.array(dtype=int),
-    instance_body: warp.array(dtype=int),
-    instance_transforms: warp.array(dtype=warp.transform),
-    instance_scalings: warp.array(dtype=warp.vec3),
-    body_q: warp.array(dtype=warp.transform),
+    instance_id: warp.array[warp.int32],
+    instance_body: warp.array[warp.int32],
+    instance_transforms: warp.array[warp.transform],
+    instance_scalings: warp.array[warp.vec3],
+    body_q: warp.array[warp.transform],
     # outputs
-    vbo_transforms: warp.array(dtype=warp.mat44),
+    vbo_transforms: warp.array[warp.mat44],
 ):
     tid = warp.tid()
     i = instance_id[tid]
@@ -309,9 +309,9 @@ def update_vbo_transforms(
 
 @warp.kernel
 def update_vbo_vertices(
-    points: warp.array(dtype=warp.vec3),
+    points: warp.array[warp.vec3],
     # outputs
-    vbo_vertices: warp.array(dtype=float, ndim=2),
+    vbo_vertices: warp.array2d[warp.float32],
 ):
     tid = warp.tid()
     p = points[tid]
@@ -322,10 +322,10 @@ def update_vbo_vertices(
 
 @warp.kernel
 def update_points_positions(
-    instance_positions: warp.array(dtype=warp.vec3),
-    instance_scalings: warp.array(dtype=warp.vec3),
+    instance_positions: warp.array[warp.vec3],
+    instance_scalings: warp.array[warp.vec3],
     # outputs
-    vbo_transforms: warp.array(dtype=warp.mat44),
+    vbo_transforms: warp.array[warp.mat44],
 ):
     tid = warp.tid()
     p = instance_positions[tid]
@@ -344,9 +344,9 @@ def update_points_positions(
 
 @warp.kernel
 def update_line_transforms(
-    lines: warp.array(dtype=warp.vec3, ndim=2),
+    lines: warp.array2d[warp.vec3],
     # outputs
-    vbo_transforms: warp.array(dtype=warp.mat44),
+    vbo_transforms: warp.array[warp.mat44],
 ):
     tid = warp.tid()
     p0 = lines[tid, 0]
@@ -373,11 +373,11 @@ def update_line_transforms(
 
 @warp.kernel
 def compute_gfx_vertices(
-    indices: warp.array(dtype=int, ndim=2),
-    vertices: warp.array(dtype=warp.vec3, ndim=1),
+    indices: warp.array2d[warp.int32],
+    vertices: warp.array[warp.vec3],
     scale: warp.vec3,
     # outputs
-    gfx_vertices: warp.array(dtype=float, ndim=2),
+    gfx_vertices: warp.array2d[warp.float32],
 ):
     tid = warp.tid()
     v0 = warp.cw_mul(vertices[indices[tid, 0]], scale)
@@ -409,12 +409,12 @@ def compute_gfx_vertices(
 
 @warp.kernel
 def compute_average_normals(
-    indices: warp.array(dtype=int, ndim=2),
-    vertices: warp.array(dtype=warp.vec3),
+    indices: warp.array2d[warp.int32],
+    vertices: warp.array[warp.vec3],
     scale: warp.vec3,
     # outputs
-    normals: warp.array(dtype=warp.vec3),
-    faces_per_vertex: warp.array(dtype=int),
+    normals: warp.array[warp.vec3],
+    faces_per_vertex: warp.array[warp.int32],
 ):
     tid = warp.tid()
     i = indices[tid, 0]
@@ -434,12 +434,12 @@ def compute_average_normals(
 
 @warp.kernel
 def assemble_gfx_vertices(
-    vertices: warp.array(dtype=warp.vec3, ndim=1),
-    normals: warp.array(dtype=warp.vec3),
-    faces_per_vertex: warp.array(dtype=int),
+    vertices: warp.array[warp.vec3],
+    normals: warp.array[warp.vec3],
+    faces_per_vertex: warp.array[warp.int32],
     scale: warp.vec3,
     # outputs
-    gfx_vertices: warp.array(dtype=float, ndim=2),
+    gfx_vertices: warp.array2d[warp.float32],
 ):
     tid = warp.tid()
     v = vertices[tid]
@@ -454,11 +454,11 @@ def assemble_gfx_vertices(
 
 @warp.kernel
 def copy_rgb_frame(
-    input_img: warp.array(dtype=warp.uint8),
+    input_img: warp.array[warp.uint8],
     width: int,
     height: int,
     # outputs
-    output_img: warp.array(dtype=float, ndim=3),
+    output_img: warp.array3d[warp.float32],
 ):
     w, v = warp.tid()
     pixel = v * width + w
@@ -475,11 +475,11 @@ def copy_rgb_frame(
 
 @warp.kernel
 def copy_rgb_frame_uint8(
-    input_img: warp.array(dtype=warp.uint8),
+    input_img: warp.array[warp.uint8],
     width: int,
     height: int,
     # outputs
-    output_img: warp.array(dtype=warp.uint8, ndim=3),
+    output_img: warp.array3d[warp.uint8],
 ):
     w, v = warp.tid()
     pixel = v * width + w
@@ -493,13 +493,13 @@ def copy_rgb_frame_uint8(
 
 @warp.kernel
 def copy_depth_frame(
-    input_img: warp.array(dtype=warp.float32),
+    input_img: warp.array[warp.float32],
     width: int,
     height: int,
     near: float,
     far: float,
     # outputs
-    output_img: warp.array(dtype=warp.float32, ndim=3),
+    output_img: warp.array3d[warp.float32],
 ):
     w, v = warp.tid()
     pixel = v * width + w
@@ -512,13 +512,13 @@ def copy_depth_frame(
 
 @warp.kernel
 def copy_rgb_frame_tiles(
-    input_img: warp.array(dtype=warp.uint8),
-    positions: warp.array(dtype=int, ndim=2),
+    input_img: warp.array[warp.uint8],
+    positions: warp.array2d[warp.int32],
     screen_width: int,
     screen_height: int,
     tile_height: int,
     # outputs
-    output_img: warp.array(dtype=float, ndim=4),
+    output_img: warp.array4d[warp.float32],
 ):
     tile, x, y = warp.tid()
     p = positions[tile]
@@ -543,13 +543,13 @@ def copy_rgb_frame_tiles(
 
 @warp.kernel
 def copy_rgb_frame_tiles_uint8(
-    input_img: warp.array(dtype=warp.uint8),
-    positions: warp.array(dtype=int, ndim=2),
+    input_img: warp.array[warp.uint8],
+    positions: warp.array2d[warp.int32],
     screen_width: int,
     screen_height: int,
     tile_height: int,
     # outputs
-    output_img: warp.array(dtype=warp.uint8, ndim=4),
+    output_img: warp.array4d[warp.uint8],
 ):
     tile, x, y = warp.tid()
     p = positions[tile]
@@ -571,15 +571,15 @@ def copy_rgb_frame_tiles_uint8(
 
 @warp.kernel
 def copy_depth_frame_tiles(
-    input_img: warp.array(dtype=warp.float32),
-    positions: warp.array(dtype=int, ndim=2),
+    input_img: warp.array[warp.float32],
+    positions: warp.array2d[warp.int32],
     screen_width: int,
     screen_height: int,
     tile_height: int,
     near: float,
     far: float,
     # outputs
-    output_img: warp.array(dtype=warp.float32, ndim=4),
+    output_img: warp.array4d[warp.float32],
 ):
     tile, x, y = warp.tid()
     p = positions[tile]
@@ -598,14 +598,14 @@ def copy_depth_frame_tiles(
 
 @warp.kernel
 def copy_rgb_frame_tile(
-    input_img: warp.array(dtype=warp.uint8),
+    input_img: warp.array[warp.uint8],
     offset_x: int,
     offset_y: int,
     screen_width: int,
     screen_height: int,
     tile_height: int,
     # outputs
-    output_img: warp.array(dtype=float, ndim=4),
+    output_img: warp.array4d[warp.float32],
 ):
     tile, x, y = warp.tid()
     qx = x + offset_x
@@ -629,14 +629,14 @@ def copy_rgb_frame_tile(
 
 @warp.kernel
 def copy_rgb_frame_tile_uint8(
-    input_img: warp.array(dtype=warp.uint8),
+    input_img: warp.array[warp.uint8],
     offset_x: int,
     offset_y: int,
     screen_width: int,
     screen_height: int,
     tile_height: int,
     # outputs
-    output_img: warp.array(dtype=warp.uint8, ndim=4),
+    output_img: warp.array4d[warp.uint8],
 ):
     tile, x, y = warp.tid()
     qx = x + offset_x

--- a/warp/_src/render/render_opengl.py
+++ b/warp/_src/render/render_opengl.py
@@ -11,7 +11,7 @@ from typing import Union
 
 import numpy as np
 
-import warp as wp
+import warp
 
 from .utils import tab10_color_map
 
@@ -20,7 +20,7 @@ _wp_module_name_ = "warp.render.render_opengl"
 Mat44 = Union[list[float], list[list[float]], np.ndarray]
 
 
-wp.set_module_options({"enable_backward": False})
+warp.set_module_options({"enable_backward": False})
 
 shape_vertex_shader = """
 #version 330 core
@@ -262,17 +262,17 @@ void main() {
 """
 
 
-@wp.kernel
+@warp.kernel
 def update_vbo_transforms(
-    instance_id: wp.array(dtype=int),
-    instance_body: wp.array(dtype=int),
-    instance_transforms: wp.array(dtype=wp.transform),
-    instance_scalings: wp.array(dtype=wp.vec3),
-    body_q: wp.array(dtype=wp.transform),
+    instance_id: warp.array(dtype=int),
+    instance_body: warp.array(dtype=int),
+    instance_transforms: warp.array(dtype=warp.transform),
+    instance_scalings: warp.array(dtype=warp.vec3),
+    body_q: warp.array(dtype=warp.transform),
     # outputs
-    vbo_transforms: wp.array(dtype=wp.mat44),
+    vbo_transforms: warp.array(dtype=warp.mat44),
 ):
-    tid = wp.tid()
+    tid = warp.tid()
     i = instance_id[tid]
     X_ws = instance_transforms[i]
     if instance_body:
@@ -282,12 +282,12 @@ def update_vbo_transforms(
                 X_ws = body_q[body] * X_ws
             else:
                 return
-    p = wp.transform_get_translation(X_ws)
-    q = wp.transform_get_rotation(X_ws)
+    p = warp.transform_get_translation(X_ws)
+    q = warp.transform_get_rotation(X_ws)
     s = instance_scalings[i]
-    rot = wp.quat_to_matrix(q)
+    rot = warp.quat_to_matrix(q)
     # transposed definition
-    vbo_transforms[tid] = wp.mat44(
+    vbo_transforms[tid] = warp.mat44(
         rot[0, 0] * s[0],
         rot[1, 0] * s[0],
         rot[2, 0] * s[0],
@@ -307,34 +307,34 @@ def update_vbo_transforms(
     )
 
 
-@wp.kernel
+@warp.kernel
 def update_vbo_vertices(
-    points: wp.array(dtype=wp.vec3),
+    points: warp.array(dtype=warp.vec3),
     # outputs
-    vbo_vertices: wp.array(dtype=float, ndim=2),
+    vbo_vertices: warp.array(dtype=float, ndim=2),
 ):
-    tid = wp.tid()
+    tid = warp.tid()
     p = points[tid]
     vbo_vertices[tid, 0] = p[0]
     vbo_vertices[tid, 1] = p[1]
     vbo_vertices[tid, 2] = p[2]
 
 
-@wp.kernel
+@warp.kernel
 def update_points_positions(
-    instance_positions: wp.array(dtype=wp.vec3),
-    instance_scalings: wp.array(dtype=wp.vec3),
+    instance_positions: warp.array(dtype=warp.vec3),
+    instance_scalings: warp.array(dtype=warp.vec3),
     # outputs
-    vbo_transforms: wp.array(dtype=wp.mat44),
+    vbo_transforms: warp.array(dtype=warp.mat44),
 ):
-    tid = wp.tid()
+    tid = warp.tid()
     p = instance_positions[tid]
-    s = wp.vec3(1.0)
+    s = warp.vec3(1.0)
     if instance_scalings:
         s = instance_scalings[tid]
     # transposed definition
     # fmt: off
-    vbo_transforms[tid] = wp.mat44(
+    vbo_transforms[tid] = warp.mat44(
         s[0],  0.0,  0.0, 0.0,
          0.0, s[1],  0.0, 0.0,
          0.0,  0.0, s[2], 0.0,
@@ -342,27 +342,27 @@ def update_points_positions(
     # fmt: on
 
 
-@wp.kernel
+@warp.kernel
 def update_line_transforms(
-    lines: wp.array(dtype=wp.vec3, ndim=2),
+    lines: warp.array(dtype=warp.vec3, ndim=2),
     # outputs
-    vbo_transforms: wp.array(dtype=wp.mat44),
+    vbo_transforms: warp.array(dtype=warp.mat44),
 ):
-    tid = wp.tid()
+    tid = warp.tid()
     p0 = lines[tid, 0]
     p1 = lines[tid, 1]
     p = 0.5 * (p0 + p1)
     d = p1 - p0
-    s = wp.length(d)
-    axis = wp.normalize(d)
-    y_up = wp.vec3(0.0, 1.0, 0.0)
-    angle = wp.acos(wp.dot(axis, y_up))
-    axis = wp.normalize(wp.cross(axis, y_up))
-    q = wp.quat_from_axis_angle(axis, -angle)
-    rot = wp.quat_to_matrix(q)
+    s = warp.length(d)
+    axis = warp.normalize(d)
+    y_up = warp.vec3(0.0, 1.0, 0.0)
+    angle = warp.acos(warp.dot(axis, y_up))
+    axis = warp.normalize(warp.cross(axis, y_up))
+    q = warp.quat_from_axis_angle(axis, -angle)
+    rot = warp.quat_to_matrix(q)
     # transposed definition
     # fmt: off
-    vbo_transforms[tid] = wp.mat44(
+    vbo_transforms[tid] = warp.mat44(
             rot[0, 0],     rot[1, 0],     rot[2, 0], 0.0,
         s * rot[0, 1], s * rot[1, 1], s * rot[2, 1], 0.0,
             rot[0, 2],     rot[1, 2],     rot[2, 2], 0.0,
@@ -371,18 +371,18 @@ def update_line_transforms(
     # fmt: on
 
 
-@wp.kernel
+@warp.kernel
 def compute_gfx_vertices(
-    indices: wp.array(dtype=int, ndim=2),
-    vertices: wp.array(dtype=wp.vec3, ndim=1),
-    scale: wp.vec3,
+    indices: warp.array(dtype=int, ndim=2),
+    vertices: warp.array(dtype=warp.vec3, ndim=1),
+    scale: warp.vec3,
     # outputs
-    gfx_vertices: wp.array(dtype=float, ndim=2),
+    gfx_vertices: warp.array(dtype=float, ndim=2),
 ):
-    tid = wp.tid()
-    v0 = wp.cw_mul(vertices[indices[tid, 0]], scale)
-    v1 = wp.cw_mul(vertices[indices[tid, 1]], scale)
-    v2 = wp.cw_mul(vertices[indices[tid, 2]], scale)
+    tid = warp.tid()
+    v0 = warp.cw_mul(vertices[indices[tid, 0]], scale)
+    v1 = warp.cw_mul(vertices[indices[tid, 1]], scale)
+    v2 = warp.cw_mul(vertices[indices[tid, 2]], scale)
     i = tid * 3
     j = i + 1
     k = i + 2
@@ -395,7 +395,7 @@ def compute_gfx_vertices(
     gfx_vertices[k, 0] = v2[0]
     gfx_vertices[k, 1] = v2[1]
     gfx_vertices[k, 2] = v2[2]
-    n = wp.normalize(wp.cross(v1 - v0, v2 - v0))
+    n = warp.normalize(warp.cross(v1 - v0, v2 - v0))
     gfx_vertices[i, 3] = n[0]
     gfx_vertices[i, 4] = n[1]
     gfx_vertices[i, 5] = n[2]
@@ -407,41 +407,41 @@ def compute_gfx_vertices(
     gfx_vertices[k, 5] = n[2]
 
 
-@wp.kernel
+@warp.kernel
 def compute_average_normals(
-    indices: wp.array(dtype=int, ndim=2),
-    vertices: wp.array(dtype=wp.vec3),
-    scale: wp.vec3,
+    indices: warp.array(dtype=int, ndim=2),
+    vertices: warp.array(dtype=warp.vec3),
+    scale: warp.vec3,
     # outputs
-    normals: wp.array(dtype=wp.vec3),
-    faces_per_vertex: wp.array(dtype=int),
+    normals: warp.array(dtype=warp.vec3),
+    faces_per_vertex: warp.array(dtype=int),
 ):
-    tid = wp.tid()
+    tid = warp.tid()
     i = indices[tid, 0]
     j = indices[tid, 1]
     k = indices[tid, 2]
-    v0 = wp.cw_mul(vertices[i], scale)
-    v1 = wp.cw_mul(vertices[j], scale)
-    v2 = wp.cw_mul(vertices[k], scale)
-    n = wp.normalize(wp.cross(v1 - v0, v2 - v0))
-    wp.atomic_add(normals, i, n)
-    wp.atomic_add(faces_per_vertex, i, 1)
-    wp.atomic_add(normals, j, n)
-    wp.atomic_add(faces_per_vertex, j, 1)
-    wp.atomic_add(normals, k, n)
-    wp.atomic_add(faces_per_vertex, k, 1)
+    v0 = warp.cw_mul(vertices[i], scale)
+    v1 = warp.cw_mul(vertices[j], scale)
+    v2 = warp.cw_mul(vertices[k], scale)
+    n = warp.normalize(warp.cross(v1 - v0, v2 - v0))
+    warp.atomic_add(normals, i, n)
+    warp.atomic_add(faces_per_vertex, i, 1)
+    warp.atomic_add(normals, j, n)
+    warp.atomic_add(faces_per_vertex, j, 1)
+    warp.atomic_add(normals, k, n)
+    warp.atomic_add(faces_per_vertex, k, 1)
 
 
-@wp.kernel
+@warp.kernel
 def assemble_gfx_vertices(
-    vertices: wp.array(dtype=wp.vec3, ndim=1),
-    normals: wp.array(dtype=wp.vec3),
-    faces_per_vertex: wp.array(dtype=int),
-    scale: wp.vec3,
+    vertices: warp.array(dtype=warp.vec3, ndim=1),
+    normals: warp.array(dtype=warp.vec3),
+    faces_per_vertex: warp.array(dtype=int),
+    scale: warp.vec3,
     # outputs
-    gfx_vertices: wp.array(dtype=float, ndim=2),
+    gfx_vertices: warp.array(dtype=float, ndim=2),
 ):
-    tid = wp.tid()
+    tid = warp.tid()
     v = vertices[tid]
     n = normals[tid] / float(faces_per_vertex[tid])
     gfx_vertices[tid, 0] = v[0] * scale[0]
@@ -452,15 +452,15 @@ def assemble_gfx_vertices(
     gfx_vertices[tid, 5] = n[2]
 
 
-@wp.kernel
+@warp.kernel
 def copy_rgb_frame(
-    input_img: wp.array(dtype=wp.uint8),
+    input_img: warp.array(dtype=warp.uint8),
     width: int,
     height: int,
     # outputs
-    output_img: wp.array(dtype=float, ndim=3),
+    output_img: warp.array(dtype=float, ndim=3),
 ):
-    w, v = wp.tid()
+    w, v = warp.tid()
     pixel = v * width + w
     pixel *= 3
     r = float(input_img[pixel + 0])
@@ -473,15 +473,15 @@ def copy_rgb_frame(
     output_img[v, w, 2] = b / 255.0
 
 
-@wp.kernel
+@warp.kernel
 def copy_rgb_frame_uint8(
-    input_img: wp.array(dtype=wp.uint8),
+    input_img: warp.array(dtype=warp.uint8),
     width: int,
     height: int,
     # outputs
-    output_img: wp.array(dtype=wp.uint8, ndim=3),
+    output_img: warp.array(dtype=warp.uint8, ndim=3),
 ):
-    w, v = wp.tid()
+    w, v = warp.tid()
     pixel = v * width + w
     pixel *= 3
     # flip vertically (OpenGL coordinates start at bottom)
@@ -491,17 +491,17 @@ def copy_rgb_frame_uint8(
     output_img[v, w, 2] = input_img[pixel + 2]
 
 
-@wp.kernel
+@warp.kernel
 def copy_depth_frame(
-    input_img: wp.array(dtype=wp.float32),
+    input_img: warp.array(dtype=warp.float32),
     width: int,
     height: int,
     near: float,
     far: float,
     # outputs
-    output_img: wp.array(dtype=wp.float32, ndim=3),
+    output_img: warp.array(dtype=warp.float32, ndim=3),
 ):
-    w, v = wp.tid()
+    w, v = warp.tid()
     pixel = v * width + w
     # flip vertically (OpenGL coordinates start at bottom)
     v = height - v - 1
@@ -510,17 +510,17 @@ def copy_depth_frame(
     output_img[v, w, 0] = -d
 
 
-@wp.kernel
+@warp.kernel
 def copy_rgb_frame_tiles(
-    input_img: wp.array(dtype=wp.uint8),
-    positions: wp.array(dtype=int, ndim=2),
+    input_img: warp.array(dtype=warp.uint8),
+    positions: warp.array(dtype=int, ndim=2),
     screen_width: int,
     screen_height: int,
     tile_height: int,
     # outputs
-    output_img: wp.array(dtype=float, ndim=4),
+    output_img: warp.array(dtype=float, ndim=4),
 ):
-    tile, x, y = wp.tid()
+    tile, x, y = warp.tid()
     p = positions[tile]
     qx = x + p[0]
     qy = y + p[1]
@@ -541,17 +541,17 @@ def copy_rgb_frame_tiles(
     output_img[tile, y, x, 2] = b / 255.0
 
 
-@wp.kernel
+@warp.kernel
 def copy_rgb_frame_tiles_uint8(
-    input_img: wp.array(dtype=wp.uint8),
-    positions: wp.array(dtype=int, ndim=2),
+    input_img: warp.array(dtype=warp.uint8),
+    positions: warp.array(dtype=int, ndim=2),
     screen_width: int,
     screen_height: int,
     tile_height: int,
     # outputs
-    output_img: wp.array(dtype=wp.uint8, ndim=4),
+    output_img: warp.array(dtype=warp.uint8, ndim=4),
 ):
-    tile, x, y = wp.tid()
+    tile, x, y = warp.tid()
     p = positions[tile]
     qx = x + p[0]
     qy = y + p[1]
@@ -559,9 +559,9 @@ def copy_rgb_frame_tiles_uint8(
     # flip vertically (OpenGL coordinates start at bottom)
     y = tile_height - y - 1
     if qx >= screen_width or qy >= screen_height:
-        output_img[tile, y, x, 0] = wp.uint8(0)
-        output_img[tile, y, x, 1] = wp.uint8(0)
-        output_img[tile, y, x, 2] = wp.uint8(0)
+        output_img[tile, y, x, 0] = warp.uint8(0)
+        output_img[tile, y, x, 1] = warp.uint8(0)
+        output_img[tile, y, x, 2] = warp.uint8(0)
         return  # prevent out-of-bounds access
     pixel *= 3
     output_img[tile, y, x, 0] = input_img[pixel + 0]
@@ -569,19 +569,19 @@ def copy_rgb_frame_tiles_uint8(
     output_img[tile, y, x, 2] = input_img[pixel + 2]
 
 
-@wp.kernel
+@warp.kernel
 def copy_depth_frame_tiles(
-    input_img: wp.array(dtype=wp.float32),
-    positions: wp.array(dtype=int, ndim=2),
+    input_img: warp.array(dtype=warp.float32),
+    positions: warp.array(dtype=int, ndim=2),
     screen_width: int,
     screen_height: int,
     tile_height: int,
     near: float,
     far: float,
     # outputs
-    output_img: wp.array(dtype=wp.float32, ndim=4),
+    output_img: warp.array(dtype=warp.float32, ndim=4),
 ):
-    tile, x, y = wp.tid()
+    tile, x, y = warp.tid()
     p = positions[tile]
     qx = x + p[0]
     qy = y + p[1]
@@ -596,18 +596,18 @@ def copy_depth_frame_tiles(
     output_img[tile, y, x, 0] = -d
 
 
-@wp.kernel
+@warp.kernel
 def copy_rgb_frame_tile(
-    input_img: wp.array(dtype=wp.uint8),
+    input_img: warp.array(dtype=warp.uint8),
     offset_x: int,
     offset_y: int,
     screen_width: int,
     screen_height: int,
     tile_height: int,
     # outputs
-    output_img: wp.array(dtype=float, ndim=4),
+    output_img: warp.array(dtype=float, ndim=4),
 ):
-    tile, x, y = wp.tid()
+    tile, x, y = warp.tid()
     qx = x + offset_x
     qy = y + offset_y
     pixel = qy * screen_width + qx
@@ -627,27 +627,27 @@ def copy_rgb_frame_tile(
     output_img[tile, y, x, 2] = b / 255.0
 
 
-@wp.kernel
+@warp.kernel
 def copy_rgb_frame_tile_uint8(
-    input_img: wp.array(dtype=wp.uint8),
+    input_img: warp.array(dtype=warp.uint8),
     offset_x: int,
     offset_y: int,
     screen_width: int,
     screen_height: int,
     tile_height: int,
     # outputs
-    output_img: wp.array(dtype=wp.uint8, ndim=4),
+    output_img: warp.array(dtype=warp.uint8, ndim=4),
 ):
-    tile, x, y = wp.tid()
+    tile, x, y = warp.tid()
     qx = x + offset_x
     qy = y + offset_y
     pixel = qy * screen_width + qx
     # flip vertically (OpenGL coordinates start at bottom)
     y = tile_height - y - 1
     if qx >= screen_width or qy >= screen_height:
-        output_img[tile, y, x, 0] = wp.uint8(0)
-        output_img[tile, y, x, 1] = wp.uint8(0)
-        output_img[tile, y, x, 2] = wp.uint8(0)
+        output_img[tile, y, x, 0] = warp.uint8(0)
+        output_img[tile, y, x, 1] = warp.uint8(0)
+        output_img[tile, y, x, 2] = warp.uint8(0)
         return  # prevent out-of-bounds access
     pixel *= 3
     output_img[tile, y, x, 0] = input_img[pixel + 0]
@@ -812,28 +812,28 @@ class ShapeInstancer:
             gl.glGenBuffers(1, self.instance_transform_gl_buffer)
         gl.glBindBuffer(gl.GL_ARRAY_BUFFER, self.instance_transform_gl_buffer)
 
-        self.instance_ids = wp.array(np.arange(self.num_instances), dtype=wp.int32, device=self.device)
+        self.instance_ids = warp.array(np.arange(self.num_instances), dtype=warp.int32, device=self.device)
         if rotations is None:
-            self.instance_transforms = wp.array(
-                [(*pos, 0.0, 0.0, 0.0, 1.0) for pos in positions], dtype=wp.transform, device=self.device
+            self.instance_transforms = warp.array(
+                [(*pos, 0.0, 0.0, 0.0, 1.0) for pos in positions], dtype=warp.transform, device=self.device
             )
         else:
-            self.instance_transforms = wp.array(
+            self.instance_transforms = warp.array(
                 [(*pos, *rot) for pos, rot in zip(positions, rotations)],
-                dtype=wp.transform,
+                dtype=warp.transform,
                 device=self.device,
             )
 
         if scalings is None:
-            self.instance_scalings = wp.array(
-                np.tile((1.0, 1.0, 1.0), (self.num_instances, 1)), dtype=wp.vec3, device=self.device
+            self.instance_scalings = warp.array(
+                np.tile((1.0, 1.0, 1.0), (self.num_instances, 1)), dtype=warp.vec3, device=self.device
             )
         else:
-            self.instance_scalings = wp.array(scalings, dtype=wp.vec3, device=self.device)
+            self.instance_scalings = warp.array(scalings, dtype=warp.vec3, device=self.device)
 
-        vbo_transforms = wp.zeros(dtype=wp.mat44, shape=(self.num_instances,), device=self.device)
+        vbo_transforms = warp.zeros(dtype=warp.mat44, shape=(self.num_instances,), device=self.device)
 
-        wp.launch(
+        warp.launch(
             update_vbo_transforms,
             dim=self.num_instances,
             inputs=[
@@ -854,7 +854,7 @@ class ShapeInstancer:
         gl.glBufferData(gl.GL_ARRAY_BUFFER, vbo_transforms.nbytes, vbo_transforms.ctypes.data, gl.GL_DYNAMIC_DRAW)
 
         # Create CUDA buffer for instance transforms
-        self._instance_transform_cuda_buffer = wp.RegisteredGLBuffer(
+        self._instance_transform_cuda_buffer = warp.RegisteredGLBuffer(
             int(self.instance_transform_gl_buffer.value), self.device
         )
 
@@ -875,7 +875,7 @@ class ShapeInstancer:
 
         gl.glBindVertexArray(0)
 
-    def update_instances(self, transforms: wp.array = None, scalings: wp.array = None, colors1=None, colors2=None):
+    def update_instances(self, transforms: warp.array = None, scalings: warp.array = None, colors1=None, colors2=None):
         gl = ShapeInstancer.gl
 
         if transforms is not None:
@@ -893,9 +893,9 @@ class ShapeInstancer:
 
         if transforms is not None or scalings is not None:
             gl.glBindVertexArray(self.vao)
-            vbo_transforms = self._instance_transform_cuda_buffer.map(dtype=wp.mat44, shape=(self.num_instances,))
+            vbo_transforms = self._instance_transform_cuda_buffer.map(dtype=warp.mat44, shape=(self.num_instances,))
 
-            wp.launch(
+            warp.launch(
                 update_vbo_transforms,
                 dim=self.num_instances,
                 inputs=[
@@ -931,7 +931,7 @@ class ShapeInstancer:
         gl = ShapeInstancer.gl
 
         gl.glBindVertexArray(self.vao)
-        self.vbo_transforms = self._instance_transform_cuda_buffer.map(dtype=wp.mat44, shape=(self.num_instances,))
+        self.vbo_transforms = self._instance_transform_cuda_buffer.map(dtype=warp.mat44, shape=(self.num_instances,))
         return self
 
     def __exit__(self, exc_type, exc_value, traceback):
@@ -1085,9 +1085,9 @@ class OpenGLRenderer:
             self.use_legacy_opengl = use_legacy_opengl
 
         if device is None:
-            self._device = wp.get_preferred_device()
+            self._device = warp.get_preferred_device()
         else:
-            self._device = wp.get_device(device)
+            self._device = warp.get_device(device)
 
         self._title = title
 
@@ -2413,7 +2413,7 @@ Instances: {len(self._instances)}"""
         gl.glBindBuffer(gl.GL_ARRAY_BUFFER, vbo)
         gl.glBufferData(gl.GL_ARRAY_BUFFER, vertices.nbytes, vertices.ctypes.data, gl.GL_STATIC_DRAW)
 
-        vertex_cuda_buffer = wp.RegisteredGLBuffer(int(vbo.value), self._device)
+        vertex_cuda_buffer = warp.RegisteredGLBuffer(int(vbo.value), self._device)
 
         ebo = gl.GLuint()
         gl.glGenBuffers(1, ebo)
@@ -2565,14 +2565,14 @@ Instances: {len(self._instances)}"""
         self._switch_context()
 
         self._add_shape_instances = False
-        self._wp_instance_transforms = wp.array(
-            [instance[3] for instance in self._instances.values()], dtype=wp.transform, device=self._device
+        self._wp_instance_transforms = warp.array(
+            [instance[3] for instance in self._instances.values()], dtype=warp.transform, device=self._device
         )
-        self._wp_instance_scalings = wp.array(
-            [instance[4] for instance in self._instances.values()], dtype=wp.vec3, device=self._device
+        self._wp_instance_scalings = warp.array(
+            [instance[4] for instance in self._instances.values()], dtype=warp.vec3, device=self._device
         )
-        self._wp_instance_bodies = wp.array(
-            [instance[1] for instance in self._instances.values()], dtype=wp.int32, device=self._device
+        self._wp_instance_bodies = warp.array(
+            [instance[1] for instance in self._instances.values()], dtype=warp.int32, device=self._device
         )
 
         gl.glUseProgram(self._shape_shader.id)
@@ -2586,7 +2586,7 @@ Instances: {len(self._instances)}"""
         gl.glBufferData(gl.GL_ARRAY_BUFFER, transforms.nbytes, transforms.ctypes.data, gl.GL_DYNAMIC_DRAW)
 
         # create CUDA buffer for instance transforms
-        self._instance_transform_cuda_buffer = wp.RegisteredGLBuffer(
+        self._instance_transform_cuda_buffer = warp.RegisteredGLBuffer(
             int(self._instance_transform_gl_buffer.value), self._device
         )
 
@@ -2637,8 +2637,8 @@ Instances: {len(self._instances)}"""
         # trigger update to the instance transforms
         self._update_shape_instances = True
 
-        self._wp_instance_ids = wp.array(instance_ids, dtype=wp.int32, device=self._device)
-        self._wp_instance_custom_ids = wp.array(instance_custom_ids, dtype=wp.int32, device=self._device)
+        self._wp_instance_ids = warp.array(instance_ids, dtype=warp.int32, device=self._device)
+        self._wp_instance_custom_ids = warp.array(instance_custom_ids, dtype=warp.int32, device=self._device)
         self._np_instance_visible = np.array(instance_visible)
         self._instance_ids = instance_ids
         self._inverse_instance_ids = inverse_instance_ids
@@ -2692,12 +2692,12 @@ Instances: {len(self._instances)}"""
         """Rebuild instance buffers after instance updates."""
         with self._shape_shader:
             self._update_shape_instances = False
-            self._wp_instance_transforms = wp.array(
-                [instance[3] for instance in self._instances.values()], dtype=wp.transform, device=self._device
+            self._wp_instance_transforms = warp.array(
+                [instance[3] for instance in self._instances.values()], dtype=warp.transform, device=self._device
             )
             self.update_body_transforms(None)
 
-    def update_body_transforms(self, body_tf: wp.array):
+    def update_body_transforms(self, body_tf: warp.array):
         """Update instance transforms from body transforms.
 
         Args:
@@ -2714,9 +2714,9 @@ Instances: {len(self._instances)}"""
             else:
                 body_q = body_tf.to(self._device)
 
-        vbo_transforms = self._instance_transform_cuda_buffer.map(dtype=wp.mat44, shape=(self._instance_count,))
+        vbo_transforms = self._instance_transform_cuda_buffer.map(dtype=warp.mat44, shape=(self._instance_count,))
 
-        wp.launch(
+        warp.launch(
             update_vbo_transforms,
             dim=self._instance_count,
             inputs=[
@@ -2769,7 +2769,7 @@ Instances: {len(self._instances)}"""
             self.clear()
             self.app.event_loop.exit()
 
-    def get_pixels(self, target_image: wp.array, split_up_tiles=True, mode="rgb", use_uint8=False):
+    def get_pixels(self, target_image: warp.array, split_up_tiles=True, mode="rgb", use_uint8=False):
         """
         Read the pixels from the frame buffer (RGB or depth are supported) into the given array.
 
@@ -2837,17 +2837,17 @@ Instances: {len(self._instances)}"""
         gl.glBindTexture(gl.GL_TEXTURE_2D, 0)
         gl.glBindBuffer(gl.GL_PIXEL_PACK_BUFFER, 0)
 
-        pbo_buffer = wp.RegisteredGLBuffer(int(self._frame_pbo.value), self._device, wp.RegisteredGLBuffer.READ_ONLY)
+        pbo_buffer = warp.RegisteredGLBuffer(int(self._frame_pbo.value), self._device, warp.RegisteredGLBuffer.READ_ONLY)
         screen_size = self.screen_height * self.screen_width
         if mode == "rgb":
-            img = pbo_buffer.map(dtype=wp.uint8, shape=(screen_size * channels))
+            img = pbo_buffer.map(dtype=warp.uint8, shape=(screen_size * channels))
         elif mode == "depth":
-            img = pbo_buffer.map(dtype=wp.float32, shape=(screen_size * channels))
+            img = pbo_buffer.map(dtype=warp.float32, shape=(screen_size * channels))
         img = img.to(target_image.device)
         if split_up_tiles:
-            positions = wp.array(self._tile_viewports, ndim=2, dtype=wp.int32, device=target_image.device)
+            positions = warp.array(self._tile_viewports, ndim=2, dtype=warp.int32, device=target_image.device)
             if mode == "rgb":
-                wp.launch(
+                warp.launch(
                     copy_rgb_frame_tiles_uint8 if use_uint8 else copy_rgb_frame_tiles,
                     dim=(self.num_tiles, self._tile_width, self._tile_height),
                     inputs=[img, positions, self.screen_width, self.screen_height, self._tile_height],
@@ -2855,7 +2855,7 @@ Instances: {len(self._instances)}"""
                     device=target_image.device,
                 )
             elif mode == "depth":
-                wp.launch(
+                warp.launch(
                     copy_depth_frame_tiles,
                     dim=(self.num_tiles, self._tile_width, self._tile_height),
                     inputs=[
@@ -2872,7 +2872,7 @@ Instances: {len(self._instances)}"""
                 )
         else:
             if mode == "rgb":
-                wp.launch(
+                warp.launch(
                     copy_rgb_frame_uint8 if use_uint8 else copy_rgb_frame,
                     dim=(self.screen_width, self.screen_height),
                     inputs=[img, self.screen_width, self.screen_height],
@@ -2880,7 +2880,7 @@ Instances: {len(self._instances)}"""
                     device=target_image.device,
                 )
             elif mode == "depth":
-                wp.launch(
+                warp.launch(
                     copy_depth_frame,
                     dim=(self.screen_width, self.screen_height),
                     inputs=[img, self.screen_width, self.screen_height, self.camera_near_plane, self.camera_far_plane],
@@ -3013,10 +3013,10 @@ Instances: {len(self._instances)}"""
                 q = (0.0, 0.0, 0.0, 1.0)
             else:
                 c = np.cross(normal, (0.0, 1.0, 0.0))
-                angle = wp.float32(np.arcsin(np.linalg.norm(c)))
-                axis = wp.vec3(np.abs(c))
-                axis = wp.normalize(axis)
-                q = wp.quat_from_axis_angle(axis, angle)
+                angle = warp.float32(np.arcsin(np.linalg.norm(c)))
+                axis = warp.vec3(np.abs(c))
+                axis = warp.normalize(axis)
+                q = warp.quat_from_axis_angle(axis, angle)
         return self.render_plane(
             "ground",
             pos,
@@ -3293,20 +3293,20 @@ Instances: {len(self._instances)}"""
 
         # No existing shape for the given mesh was found, or its topology may have changed,
         # so we need to define a new one either way.
-        with wp.ScopedDevice(self._device):
+        with warp.ScopedDevice(self._device):
             if smooth_shading:
-                normals = wp.zeros(point_count, dtype=wp.vec3)
-                vertices = wp.array(points, dtype=wp.vec3)
-                faces_per_vertex = wp.zeros(point_count, dtype=int)
-                wp.launch(
+                normals = warp.zeros(point_count, dtype=warp.vec3)
+                vertices = warp.array(points, dtype=warp.vec3)
+                faces_per_vertex = warp.zeros(point_count, dtype=int)
+                warp.launch(
                     compute_average_normals,
                     dim=idx_count,
-                    inputs=[wp.array(indices, dtype=int), vertices, scale],
+                    inputs=[warp.array(indices, dtype=int), vertices, scale],
                     outputs=[normals, faces_per_vertex],
                     record_tape=False,
                 )
-                gfx_vertices = wp.zeros((point_count, 8), dtype=float)
-                wp.launch(
+                gfx_vertices = warp.zeros((point_count, 8), dtype=float)
+                warp.launch(
                     assemble_gfx_vertices,
                     dim=point_count,
                     inputs=[vertices, normals, faces_per_vertex, scale],
@@ -3316,11 +3316,11 @@ Instances: {len(self._instances)}"""
                 gfx_vertices = gfx_vertices.numpy()
                 gfx_indices = indices.flatten()
             else:
-                gfx_vertices = wp.zeros((idx_count * 3, 8), dtype=float)
-                wp.launch(
+                gfx_vertices = warp.zeros((idx_count * 3, 8), dtype=float)
+                warp.launch(
                     compute_gfx_vertices,
                     dim=idx_count,
-                    inputs=[wp.array(indices, dtype=int), wp.array(points, dtype=wp.vec3), scale],
+                    inputs=[warp.array(indices, dtype=int), warp.array(points, dtype=warp.vec3), scale],
                     outputs=[gfx_vertices],
                     record_tape=False,
                 )
@@ -3426,13 +3426,13 @@ Instances: {len(self._instances)}"""
         if len(points) == 0:
             return
 
-        if isinstance(points, wp.array):
+        if isinstance(points, warp.array):
             wp_points = points
         else:
-            wp_points = wp.array(points, dtype=wp.vec3, device=self._device)
+            wp_points = warp.array(points, dtype=warp.vec3, device=self._device)
 
         if name not in self._shape_instancers:
-            np_points = points.numpy() if isinstance(points, wp.array) else points
+            np_points = points.numpy() if isinstance(points, warp.array) else points
             instancer = ShapeInstancer(self._shape_shader, self._device)
             radius_is_scalar = np.isscalar(radius)
             if radius_is_scalar:
@@ -3452,11 +3452,11 @@ Instances: {len(self._instances)}"""
         else:
             instancer = self._shape_instancers[name]
             if len(points) != instancer.num_instances:
-                np_points = points.numpy() if isinstance(points, wp.array) else points
+                np_points = points.numpy() if isinstance(points, warp.array) else points
                 instancer.allocate_instances(np_points)
 
         with instancer:
-            wp.launch(
+            warp.launch(
                 update_points_positions,
                 dim=len(points),
                 inputs=[wp_points, instancer.instance_scalings],
@@ -3482,9 +3482,9 @@ Instances: {len(self._instances)}"""
                 instancer.allocate_instances(np.zeros((len(lines), 3)))
             instancer.update_colors(color, color)
 
-        lines_wp = wp.array(lines, dtype=wp.vec3, ndim=2, device=self._device)
+        lines_wp = warp.array(lines, dtype=warp.vec3, ndim=2, device=self._device)
         with instancer:
-            wp.launch(
+            warp.launch(
                 update_line_transforms,
                 dim=len(lines),
                 inputs=[lines_wp],
@@ -3547,16 +3547,16 @@ Instances: {len(self._instances)}"""
             shape: Shape ID returned by :meth:`register_shape`.
             points: Vertex positions as a :class:`warp.array` or array-like.
         """
-        if isinstance(points, wp.array):
+        if isinstance(points, warp.array):
             wp_points = points.to(self._device)
         else:
-            wp_points = wp.array(points, dtype=wp.vec3, device=self._device)
+            wp_points = warp.array(points, dtype=warp.vec3, device=self._device)
 
         cuda_buffer = self._shape_gl_buffers[shape][4]
         vertices_shape = self._shapes[shape][0].shape
-        vbo_vertices = cuda_buffer.map(dtype=wp.float32, shape=vertices_shape)
+        vbo_vertices = cuda_buffer.map(dtype=warp.float32, shape=vertices_shape)
 
-        wp.launch(
+        warp.launch(
             update_vbo_vertices,
             dim=vertices_shape[0],
             inputs=[wp_points],

--- a/warp/_src/render/render_opengl.py
+++ b/warp/_src/render/render_opengl.py
@@ -1018,7 +1018,7 @@ class OpenGLRenderer:
         enable_backface_culling: bool = True,
         enable_mouse_interaction: bool = True,
         enable_keyboard_interaction: bool = True,
-        device: wp.DeviceLike = None,
+        device: warp.DeviceLike = None,
         use_legacy_opengl: bool | None = None,
     ):
         """Initialize the OpenGL renderer.

--- a/warp/_src/sparse.py
+++ b/warp/_src/sparse.py
@@ -315,11 +315,11 @@ def bsr_matrix_t(dtype: BlockType):
         """Number of columns of blocks."""
         nnz: int
         """Upper bound for the number of non-zeros."""
-        offsets: wp.array(dtype=int)
+        offsets: wp.array[int]
         """Array of size at least ``1 + nrow``."""
-        columns: wp.array(dtype=int)
+        columns: wp.array[int]
         """Array of size at least equal to ``nnz``."""
-        values: wp.array(dtype=dtype)
+        values: wp.array[dtype]
 
     module = wp.get_module(BsrMatrix.__module__)
 
@@ -442,11 +442,11 @@ _zero_value_masks = {
 @wp.kernel
 def _bsr_accumulate_triplet_values(
     row_count: int,
-    tpl_summed_offsets: wp.array(dtype=int),
-    tpl_summed_indices: wp.array(dtype=int),
-    tpl_values: wp.array3d(dtype=Any),
-    bsr_offsets: wp.array(dtype=int),
-    bsr_values: wp.array3d(dtype=Any),
+    tpl_summed_offsets: wp.array[int],
+    tpl_summed_indices: wp.array[int],
+    tpl_values: wp.array3d[Any],
+    bsr_offsets: wp.array[int],
+    bsr_values: wp.array3d[Any],
 ):
     block, i, j = wp.tid()
 
@@ -759,7 +759,7 @@ def _extract_matrix_and_scale(bsr: BsrMatrixOrExpression):
 
 @wp.func
 def bsr_row_index(
-    offsets: wp.array(dtype=int),
+    offsets: wp.array[int],
     row_count: int,
     block_index: int,
 ) -> int:
@@ -777,8 +777,8 @@ def bsr_row_index(
 def bsr_block_index(
     row: int,
     col: int,
-    bsr_offsets: wp.array(dtype=int),
-    bsr_columns: wp.array(dtype=int),
+    bsr_offsets: wp.array[int],
+    bsr_columns: wp.array[int],
 ) -> int:
     """Return the index of the block at block-coordinates (row, col), or -1 if no such block exists.
 
@@ -811,10 +811,10 @@ def _bsr_assign_list_blocks(
     dest_subrows: int,
     dest_subcols: int,
     src_row_count: int,
-    src_offsets: wp.array(dtype=int),
-    src_columns: wp.array(dtype=int),
-    dest_rows: wp.array(dtype=int),
-    dest_cols: wp.array(dtype=int),
+    src_offsets: wp.array[int],
+    src_columns: wp.array[int],
+    dest_rows: wp.array[int],
+    dest_cols: wp.array[int],
 ):
     block, subrow, subcol = wp.tid()
     dest_block = (block * src_subcols + subcol) * src_subrows + subrow
@@ -838,12 +838,12 @@ def _bsr_assign_copy_blocks(
     dest_subrows: int,
     dest_subcols: int,
     src_row_count: int,
-    src_offsets: wp.array(dtype=int),
-    src_columns: wp.array(dtype=int),
-    src_values: wp.array3d(dtype=Any),
-    dest_offsets: wp.array(dtype=int),
-    dest_columns: wp.array(dtype=int),
-    dest_values: wp.array3d(dtype=Any),
+    src_offsets: wp.array[int],
+    src_columns: wp.array[int],
+    src_values: wp.array3d[Any],
+    dest_offsets: wp.array[int],
+    dest_columns: wp.array[int],
+    dest_values: wp.array3d[Any],
 ):
     src_block = wp.tid()
     src_block, subrow, subcol = wp.tid()
@@ -1079,13 +1079,13 @@ def bsr_copy(
 def _bsr_transpose_values(
     col_count: int,
     scale: Any,
-    bsr_offsets: wp.array(dtype=int),
-    bsr_columns: wp.array(dtype=int),
-    bsr_values: wp.array3d(dtype=Any),
-    block_index_map: wp.array(dtype=int),
-    transposed_bsr_offsets: wp.array(dtype=int),
-    transposed_bsr_columns: wp.array(dtype=int),
-    transposed_bsr_values: wp.array3d(dtype=Any),
+    bsr_offsets: wp.array[int],
+    bsr_columns: wp.array[int],
+    bsr_values: wp.array3d[Any],
+    block_index_map: wp.array[int],
+    transposed_bsr_offsets: wp.array[int],
+    transposed_bsr_columns: wp.array[int],
+    transposed_bsr_values: wp.array3d[Any],
 ):
     block, i, j = wp.tid()
 
@@ -1213,10 +1213,10 @@ def bsr_transposed(A: BsrMatrixOrExpression) -> BsrMatrix:
 @wp.kernel
 def _bsr_get_diag_kernel(
     scale: Any,
-    A_offsets: wp.array(dtype=int),
-    A_columns: wp.array(dtype=int),
-    A_values: wp.array3d(dtype=Any),
-    out: wp.array3d(dtype=Any),
+    A_offsets: wp.array[int],
+    A_columns: wp.array[int],
+    A_values: wp.array3d[Any],
+    out: wp.array3d[Any],
 ):
     row, br, bc = wp.tid()
 
@@ -1261,8 +1261,8 @@ def bsr_get_diag(A: BsrMatrixOrExpression[BlockType], out: Array[BlockType] | No
 @wp.kernel(enable_backward=False)
 def _bsr_set_diag_kernel(
     nnz: int,
-    A_offsets: wp.array(dtype=int),
-    A_columns: wp.array(dtype=int),
+    A_offsets: wp.array[int],
+    A_columns: wp.array[int],
 ):
     row = wp.tid()
     A_offsets[row] = wp.min(row, nnz)
@@ -1429,7 +1429,7 @@ def bsr_identity(
 @wp.kernel
 def _bsr_scale_kernel(
     alpha: Any,
-    values: wp.array(dtype=Any),
+    values: wp.array[Any],
 ):
     row = wp.tid()
     values[row] = alpha * values[row]
@@ -1438,7 +1438,7 @@ def _bsr_scale_kernel(
 @wp.kernel
 def _bsr_scale_kernel(
     alpha: Any,
-    values: wp.array3d(dtype=Any),
+    values: wp.array3d[Any],
 ):
     row, br, bc = wp.tid()
     values[row, br, bc] = alpha * values[row, br, bc]
@@ -1467,7 +1467,7 @@ def bsr_scale(x: BsrMatrixOrExpression, alpha: Scalar) -> BsrMatrix:
 
 
 @wp.kernel(enable_backward=False)
-def _bsr_get_block_row(row_count: int, bsr_offsets: wp.array(dtype=int), rows: wp.array(dtype=int)):
+def _bsr_get_block_row(row_count: int, bsr_offsets: wp.array[int], rows: wp.array[int]):
     block = wp.tid()
     rows[block] = bsr_row_index(bsr_offsets, row_count, block)
 
@@ -1476,12 +1476,12 @@ def _bsr_get_block_row(row_count: int, bsr_offsets: wp.array(dtype=int), rows: w
 def _bsr_axpy_add_block(
     src_offset: int,
     scale: Any,
-    rows: wp.array(dtype=int),
-    cols: wp.array(dtype=int),
-    dst_offsets: wp.array(dtype=int),
-    dst_columns: wp.array(dtype=int),
-    src_values: wp.array3d(dtype=Any),
-    dst_values: wp.array3d(dtype=Any),
+    rows: wp.array[int],
+    cols: wp.array[int],
+    dst_offsets: wp.array[int],
+    dst_columns: wp.array[int],
+    src_values: wp.array3d[Any],
+    dst_values: wp.array3d[Any],
 ):
     i, br, bc = wp.tid()
     row = rows[i + src_offset]
@@ -1496,12 +1496,12 @@ def _bsr_axpy_add_block(
 def _bsr_axpy_masked(
     alpha: Any,
     row_count: int,
-    src_offsets: wp.array(dtype=int),
-    src_columns: wp.array(dtype=int),
-    src_values: wp.array3d(dtype=Any),
-    dst_offsets: wp.array(dtype=int),
-    dst_columns: wp.array(dtype=int),
-    dst_values: wp.array3d(dtype=Any),
+    src_offsets: wp.array[int],
+    src_columns: wp.array[int],
+    src_values: wp.array3d[Any],
+    dst_offsets: wp.array[int],
+    dst_columns: wp.array[int],
+    dst_values: wp.array3d[Any],
 ):
     block, br, bc = wp.tid()
 
@@ -1724,12 +1724,12 @@ def make_bsr_mm_count_coeffs(tile_size):
     def bsr_mm_count_coeffs(
         y_ncol: int,
         z_nnz: int,
-        x_offsets: wp.array(dtype=int),
-        x_columns: wp.array(dtype=int),
-        y_offsets: wp.array(dtype=int),
-        y_columns: wp.array(dtype=int),
-        row_min: wp.array(dtype=int),
-        block_counts: wp.array(dtype=int),
+        x_offsets: wp.array[int],
+        x_columns: wp.array[int],
+        y_offsets: wp.array[int],
+        y_columns: wp.array[int],
+        row_min: wp.array[int],
+        block_counts: wp.array[int],
     ):
         row, lane = wp.tid()
         row_count = int(0)
@@ -1783,15 +1783,15 @@ def _bsr_mm_list_coeffs(
     copied_z_nnz: int,
     mm_nnz: int,
     x_nrow: int,
-    x_offsets: wp.array(dtype=int),
-    x_columns: wp.array(dtype=int),
-    y_offsets: wp.array(dtype=int),
-    y_columns: wp.array(dtype=int),
-    mm_row_min: wp.array(dtype=int),
-    mm_offsets: wp.array(dtype=int),
-    mm_rows: wp.array(dtype=int),
-    mm_cols: wp.array(dtype=int),
-    mm_src_blocks: wp.array(dtype=int),
+    x_offsets: wp.array[int],
+    x_columns: wp.array[int],
+    y_offsets: wp.array[int],
+    y_columns: wp.array[int],
+    mm_row_min: wp.array[int],
+    mm_offsets: wp.array[int],
+    mm_rows: wp.array[int],
+    mm_cols: wp.array[int],
+    mm_src_blocks: wp.array[int],
 ):
     mm_block = wp.tid() + copied_z_nnz
 
@@ -1835,9 +1835,9 @@ def _bsr_mm_list_coeffs(
 def _bsr_mm_use_triplets(
     row: int,
     mm_block: int,
-    mm_row_min: wp.array(dtype=int),
-    row_offsets: wp.array(dtype=int),
-    summed_triplet_offsets: wp.array(dtype=int),
+    mm_row_min: wp.array[int],
+    row_offsets: wp.array[int],
+    summed_triplet_offsets: wp.array[int],
 ):
     x_beg = row_offsets[row]
     x_end = row_offsets[row + 1]
@@ -1859,19 +1859,19 @@ def _bsr_mm_use_triplets(
 @wp.kernel(enable_backward=False)
 def _bsr_mm_compute_values(
     alpha: Any,
-    x_offsets: wp.array(dtype=int),
-    x_columns: wp.array(dtype=int),
-    x_values: wp.array(dtype=Any),
-    y_offsets: wp.array(dtype=int),
-    y_columns: wp.array(dtype=int),
-    y_values: wp.array(dtype=Any),
-    mm_row_min: wp.array(dtype=int),
-    summed_triplet_offsets: wp.array(dtype=int),
+    x_offsets: wp.array[int],
+    x_columns: wp.array[int],
+    x_values: wp.array[Any],
+    y_offsets: wp.array[int],
+    y_columns: wp.array[int],
+    y_values: wp.array[Any],
+    mm_row_min: wp.array[int],
+    summed_triplet_offsets: wp.array[int],
     summed_triplet_src_blocks: wp.indexedarray(dtype=int),
     mm_row_count: int,
-    mm_offsets: wp.array(dtype=int),
-    mm_cols: wp.array(dtype=int),
-    mm_values: wp.array(dtype=Any),
+    mm_offsets: wp.array[int],
+    mm_cols: wp.array[int],
+    mm_values: wp.array[Any],
 ):
     mm_block = wp.tid()
 
@@ -1914,8 +1914,8 @@ def make_bsr_mm_compute_values_tiled_outer(subblock_rows, subblock_cols, block_d
 
     @dynamic_func(suffix=suffix)
     def _outer_product(
-        x_values: wp.array2d(dtype=Any),
-        y_values: wp.array2d(dtype=Any),
+        x_values: wp.array2d[Any],
+        y_values: wp.array2d[Any],
         brow_off: int,
         bcol_off: int,
         block_col: int,
@@ -1935,19 +1935,19 @@ def make_bsr_mm_compute_values_tiled_outer(subblock_rows, subblock_cols, block_d
     @dynamic_kernel(suffix=suffix, kernel_options={"enable_backward": False})
     def bsr_mm_compute_values(
         alpha: Any,
-        x_offsets: wp.array(dtype=int),
-        x_columns: wp.array(dtype=int),
-        x_values: wp.array3d(dtype=Any),
-        y_offsets: wp.array(dtype=int),
-        y_columns: wp.array(dtype=int),
-        y_values: wp.array3d(dtype=Any),
-        mm_row_min: wp.array(dtype=int),
-        summed_triplet_offsets: wp.array(dtype=int),
+        x_offsets: wp.array[int],
+        x_columns: wp.array[int],
+        x_values: wp.array3d[Any],
+        y_offsets: wp.array[int],
+        y_columns: wp.array[int],
+        y_values: wp.array3d[Any],
+        mm_row_min: wp.array[int],
+        summed_triplet_offsets: wp.array[int],
         summed_triplet_src_blocks: wp.indexedarray(dtype=int),
         mm_row_count: int,
-        mm_offsets: wp.array(dtype=int),
-        mm_cols: wp.array(dtype=int),
-        mm_values: wp.array3d(dtype=Any),
+        mm_offsets: wp.array[int],
+        mm_cols: wp.array[int],
+        mm_values: wp.array3d[Any],
     ):
         mm_block, subrow, subcol, lane = wp.tid()
 
@@ -2420,12 +2420,12 @@ def make_bsr_mv_kernel(block_cols: int):
     @dynamic_kernel(suffix=block_cols, kernel_options={"enable_backward": False})
     def bsr_mv_kernel(
         alpha: Any,
-        A_offsets: wp.array(dtype=int),
-        A_columns: wp.array(dtype=int),
-        A_values: wp.array3d(dtype=Any),
-        x: wp.array(dtype=Any),
+        A_offsets: wp.array[int],
+        A_columns: wp.array[int],
+        A_values: wp.array3d[Any],
+        x: wp.array[Any],
         beta: Any,
-        y: wp.array(dtype=Any),
+        y: wp.array[Any],
     ):
         row, subrow = wp.tid()
 
@@ -2460,12 +2460,12 @@ def make_bsr_mv_tiled_kernel(tile_size: int):
     @dynamic_kernel(suffix=tile_size, kernel_options={"enable_backward": False})
     def bsr_mv_tiled_kernel(
         alpha: Any,
-        A_offsets: wp.array(dtype=int),
-        A_columns: wp.array(dtype=int),
-        A_values: wp.array3d(dtype=Any),
-        x: wp.array(dtype=Any),
+        A_offsets: wp.array[int],
+        A_columns: wp.array[int],
+        A_values: wp.array3d[Any],
+        x: wp.array[Any],
         beta: Any,
-        y: wp.array(dtype=Any),
+        y: wp.array[Any],
     ):
         row, subrow, lane = wp.tid()
 
@@ -2510,11 +2510,11 @@ def make_bsr_mv_transpose_kernel(block_rows: int):
     def bsr_mv_transpose_kernel(
         alpha: Any,
         A_row_count: int,
-        A_offsets: wp.array(dtype=int),
-        A_columns: wp.array(dtype=int),
-        A_values: wp.array3d(dtype=Any),
-        x: wp.array(dtype=Any),
-        y: wp.array(dtype=Any),
+        A_offsets: wp.array[int],
+        A_columns: wp.array[int],
+        A_values: wp.array3d[Any],
+        x: wp.array[Any],
+        y: wp.array[Any],
     ):
         block, subcol = wp.tid()
 

--- a/warp/_src/tape.py
+++ b/warp/_src/tape.py
@@ -221,7 +221,7 @@ class Tape:
         """Return the adjoint container for a kernel argument.
 
         For :class:`warp.array` inputs with gradients enabled, this returns
-        :attr:`warp.array.grad` and tracks it in :attr:`warp.Tape.gradients` so it can
+        :attr:`warp.array.grad` and tracks it in ``gradients`` so it can
         be zeroed later. For instances created with :func:`warp.struct`, a mirrored
         struct is created with adjoints for array fields, and nested structs are
         handled recursively. Non-differentiable values are passed through unchanged.

--- a/warp/_src/texture.py
+++ b/warp/_src/texture.py
@@ -194,7 +194,7 @@ class Texture:
     def __init__(
         self,
         ndim: int,
-        data: np.ndarray | array | None = None,
+        data: numpy.ndarray | array | None = None,
         width: int = 0,
         height: int = 0,
         depth: int = 0,
@@ -511,7 +511,7 @@ class Texture:
         else:
             return (*shape, self._num_channels)
 
-    def copy_from(self, src: array | np.ndarray | Texture):
+    def copy_from(self, src: array | numpy.ndarray | Texture):
         """Copy texture data from a source.
 
         Args:
@@ -601,7 +601,7 @@ class Texture:
             self_array = array(ptr=self._host_ptr, shape=self._get_shape(), dtype=self.dtype, device=self.device)
             warp._src.context.copy(self_array, src)
 
-    def copy_to(self, dst: array | np.ndarray | Texture):
+    def copy_to(self, dst: array | numpy.ndarray | Texture):
         """Copy texture data to a destination.
 
         Args:
@@ -921,7 +921,7 @@ class Texture1D(Texture):
 
     def __init__(
         self,
-        data: np.ndarray | array | None = None,
+        data: numpy.ndarray | array | None = None,
         width: int = 0,
         num_channels: int = 0,
         dtype=None,
@@ -997,7 +997,7 @@ class Texture2D(Texture):
 
     def __init__(
         self,
-        data: np.ndarray | array | None = None,
+        data: numpy.ndarray | array | None = None,
         width: int = 0,
         height: int = 0,
         num_channels: int = 0,
@@ -1075,7 +1075,7 @@ class Texture3D(Texture):
 
     def __init__(
         self,
-        data: np.ndarray | array | None = None,
+        data: numpy.ndarray | array | None = None,
         width: int = 0,
         height: int = 0,
         depth: int = 0,

--- a/warp/_src/torch.py
+++ b/warp/_src/torch.py
@@ -189,7 +189,7 @@ dtype_is_compatible.compatible_sets = None
 # wrap a torch tensor to a wp array, data is not copied
 def from_torch(
     t: torch.Tensor,
-    dtype: warp.DType | None = None,
+    dtype: type | None = None,
     requires_grad: bool | None = None,
     grad=None,
     return_ctype: bool = False,

--- a/warp/_src/types.py
+++ b/warp/_src/types.py
@@ -4253,7 +4253,7 @@ def from_ptr(ptr, length, dtype=None, shape=None, device=None):
     .. deprecated::
         Use the :class:`array` constructor with a ``ptr`` argument instead.
 
-    For OmniGraph applications, use :func:`from_omni_graph_ptr`.
+    For OmniGraph applications, use :func:`warp.from_omni_graph_ptr`.
     To create an array from a C pointer, use the :class:`array` constructor
     with the ``ptr`` argument as a ``uint64`` representing the memory address.
 
@@ -6451,7 +6451,7 @@ class MeshQueryRay:
         normal (vec3f): Face normal.
 
     See Also:
-        :func:`mesh_query_ray`.
+        :func:`mesh_query_ray() <warp._src.lang.mesh_query_ray>`.
     """
 
     from warp._src.codegen import Var as _Var  # noqa: PLC0415

--- a/warp/_src/types.py
+++ b/warp/_src/types.py
@@ -4098,7 +4098,7 @@ class array(Array[DType, NDim]):
         Note: The transpose operation will return an array with a non-contiguous access pattern.
 
         Args:
-            axes (optional): Specifies the how the axes are permuted. If not specified, the axes order will be reversed.
+            axes: Specifies the how the axes are permuted. If not specified, the axes order will be reversed.
         """
         # noop if 1d array
         if self.ndim == 1:
@@ -6025,7 +6025,7 @@ class Volume:
 
         Args:
             min_world: The 3D coordinate of the lower corner of the volume.
-            voxel_size (float or array-like): The size of each voxel in spatial
+            voxel_size: The size of each voxel in spatial
                 coordinates. Can be a scalar for isotropic voxels or a 3-element
                 sequence ``(sx, sy, sz)`` for anisotropic voxels.
             bg_value: Background value
@@ -6126,13 +6126,13 @@ class Volume:
         the resulting tiles will be available in the new volume.
 
         Args:
-            min (array-like): Lower 3D coordinates of the bounding box in index space or world space, inclusive.
-            max (array-like): Upper 3D coordinates of the bounding box in index space or world space, inclusive.
-            voxel_size (float or array-like): Voxel size(s) of the new volume. Can be a scalar for isotropic
+            min: Lower 3D coordinates of the bounding box in index space or world space, inclusive.
+            max: Upper 3D coordinates of the bounding box in index space or world space, inclusive.
+            voxel_size: Voxel size(s) of the new volume. Can be a scalar for isotropic
                 voxels or a 3-element sequence ``(sx, sy, sz)`` for anisotropic voxels.
-            bg_value (float or array-like): Value of unallocated voxels of the volume, also defines the volume's type,
+            bg_value: Value of unallocated voxels of the volume, also defines the volume's type,
               a :class:`warp.vec3` volume is created if this is `array-like`, otherwise a float volume is created
-            translation (array-like): Translation between the index and world spaces.
+            translation: Translation between the index and world spaces.
             device: The CUDA device to create the volume on, e.g.: ``"cuda"`` or ``"cuda:0"``.
         """
         voxel_size = cls._normalize_voxel_size(voxel_size)
@@ -6240,12 +6240,12 @@ class Volume:
               The array may use an integer scalar type (2D N-by-3 array of :class:`warp.int32` or 1D array of :class:`warp.vec3i` values), indicating index space positions,
               or a floating point scalar type (2D N-by-3 array of :class:`warp.float32` or 1D array of :class:`warp.vec3f` values), indicating world space positions.
               Repeated points per tile are allowed and will be efficiently deduplicated.
-            voxel_size (float or array-like): Voxel size(s) of the new volume. Ignored if ``transform`` is given.
-            bg_value (array-like, scalar or None): Value of unallocated voxels of the volume, also defines the volume's type.
+            voxel_size: Voxel size(s) of the new volume. Ignored if ``transform`` is given.
+            bg_value: Value of unallocated voxels of the volume, also defines the volume's type.
               An index volume will be created if ``bg_value`` is ``None``.
               Other supported grid types are ``int``, ``float``, ``vec3f``, and ``vec4f``.
-            translation (array-like): Translation between the index and world spaces.
-            transform (array-like): Linear transform between the index and world spaces.
+            translation: Translation between the index and world spaces.
+            transform: Linear transform between the index and world spaces.
               If ``None``, deduced from ``voxel_size``.
             device: The CUDA device to create the volume on, e.g. ``"cuda"`` or ``"cuda:0"``.
 
@@ -6346,9 +6346,9 @@ class Volume:
                 The array may use an integer scalar type (2D N-by-3 array of :class:`warp.int32` or 1D array of :class:`warp.vec3i` values), indicating index space positions,
                 or a floating point scalar type (2D N-by-3 array of :class:`warp.float32` or 1D array of :class:`warp.vec3f` values), indicating world space positions.
                 Repeated points per tile are allowed and will be efficiently deduplicated.
-            voxel_size (float or array-like): Voxel size(s) of the new volume. Ignored if ``transform`` is given.
-            translation (array-like): Translation between the index and world spaces.
-            transform (array-like): Linear transform between the index and world spaces.
+            voxel_size: Voxel size(s) of the new volume. Ignored if ``transform`` is given.
+            translation: Translation between the index and world spaces.
+            transform: Linear transform between the index and world spaces.
               If ``None``, deduced from ``voxel_size``.
             device: The CUDA device to create the volume on, e.g. ``"cuda"`` or ``"cuda:0"``.
 

--- a/warp/_src/types.py
+++ b/warp/_src/types.py
@@ -4253,7 +4253,7 @@ def from_ptr(ptr, length, dtype=None, shape=None, device=None):
     .. deprecated::
         Use the :class:`array` constructor with a ``ptr`` argument instead.
 
-    For OmniGraph applications, use :func:`warp.from_omni_graph_ptr`.
+    For OmniGraph applications, use ``omni.warp.nodes.from_omni_graph_ptr()``.
     To create an array from a C pointer, use the :class:`array` constructor
     with the ``ptr`` argument as a ``uint64`` representing the memory address.
 

--- a/warp/_src/utils.py
+++ b/warp/_src/utils.py
@@ -191,8 +191,8 @@ def segmented_sort_pairs(
     keys,
     values,
     count: int,
-    segment_start_indices: wp.array(dtype=wp.int32),
-    segment_end_indices: wp.array(dtype=wp.int32) = None,
+    segment_start_indices: wp.array[wp.int32],
+    segment_end_indices: wp.array[wp.int32] = None,
 ):
     """Sort key-value pairs within segments.
 


### PR DESCRIPTION
## Summary

Enable `nitpicky = True` in `docs/conf.py` to catch unresolved cross-references during documentation builds. Resolves all **1428 warnings** through source-level fixes and targeted ignore patterns.

## Changes

### Commit 1: Enable nitpicky mode + ignore patterns
- Set `nitpicky = True` in `docs/conf.py`
- Fix docstring cross-references (add `warp.` prefix, correct intersphinx roles)
- Add `nitpick_ignore_regex` patterns for genuinely unresolvable types (ctypes-based geometric types, type aliases, FEM internal types, autosummary stubs)

### Commit 2: Replace `wp.*` with `warp.*` in annotations and docstrings
- Convert `wp.` → `warp.` in string annotations and docstrings across 11 files
- Full `wp` → `warp` conversion in `math.py` (eliminates dual-import pattern)
- Add Sphinx hooks (`rewrite_wp_aliases`, `rewrite_wp_in_docstrings`, `resolve_wp_aliases`) as safety nets
- Remove blanket `wp.*` ignore pattern — all `wp.*` warnings resolved at source level

## Motivation
Nitpicky mode catches broken cross-references early, preventing documentation link rot. The `wp.` alias used in `warp/_src/` files is not resolvable by Sphinx (which knows the module as `warp`, not `wp`), so annotations visible to Sphinx should use the canonical `warp.` name.

## Testing
`python3 -m sphinx -b html docs docs/_build/html` completes with **0 warnings**.